### PR TITLE
Requested improvements

### DIFF
--- a/src/main/scala/example/Task1RepartitioningApproach.scala
+++ b/src/main/scala/example/Task1RepartitioningApproach.scala
@@ -10,8 +10,6 @@ object Task1RepartitioningApproach {
       spark: SparkSession,
       notCompletedOrdersDF: DataFrame,
       completedOrdersDF: DataFrame,
-      notCompletedPaymentsDF: DataFrame,
-      completedPaymentsDF: DataFrame,
       usersDF: DataFrame,
       productsDF: DataFrame,
       categoriesDF: DataFrame
@@ -25,14 +23,7 @@ object Task1RepartitioningApproach {
     categoriesDF
       .repartition(col("CategoryId"))
       .createOrReplaceTempView("categories")
-//  completedPaymentsDF
-//    .createOrReplaceTempView("completed_payments")
-//  notCompletedPaymentsDF
-//    .createOrReplaceTempView("not_completed_payments")
-//  completedOrdersDF
-//    .createOrReplaceTempView("completed_orders")
-//  notCompletedOrdersDF
-//    .createOrReplaceTempView("not_completed_orders")
+
     completedOrdersDF
       .repartition(col("UserId"))
       .union(notCompletedOrdersDF
@@ -77,8 +68,6 @@ object Task1RepartitioningApproach {
     //            +- Sort [CategoryId#148 ASC NULLS FIRST], false, 0
     //            +- Exchange hashpartitioning(CategoryId#148, 200), REPARTITION_BY_COL, [plan_id=84]
     //            +- LocalTableScan [CategoryId#148]
-
-    // groupedByUsersAndCategoriesDF.show()
 
     groupedByUsersAndCategoriesDF
   }

--- a/src/main/scala/example/Task1RepartitioningApproach.scala
+++ b/src/main/scala/example/Task1RepartitioningApproach.scala
@@ -3,9 +3,22 @@ package example
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions.col
 
+/** Represents an algorithm for Task 1, repartition-based approach.
+ *  QUERY: Find spendings (both already paid or not) of different users on products from different categories.
+ */
+
 object Task1RepartitioningApproach {
   // QUERY: Find spendings (both already paid or not) of different users on products from different categories.
 
+  /** An algorithm for Task 1, repartition-based approach
+   *
+   * @param notCompletedOrdersDF set of not completed orders
+   * @param completedOrdersDF set of completed orders
+   * @param usersDF set of users
+   * @param productsDF set of products
+   * @param categoriesDF set of categories
+   * @return Spendings (both already paid or not) of different users on products from different categories.
+   */
   def transformationTask1WithRepartitioningApproach(
       notCompletedOrdersDF: DataFrame,
       completedOrdersDF: DataFrame,

--- a/src/main/scala/example/Task1RepartitioningApproach.scala
+++ b/src/main/scala/example/Task1RepartitioningApproach.scala
@@ -30,7 +30,16 @@ object Task1RepartitioningApproach {
         .repartition(col("UserId")))
       .createOrReplaceTempView("orders")
 
-    val groupedByUsersAndCategoriesDF = spark.sql("SELECT users.UserId AS ConsideredUserId, categories.CategoryId AS ConsideredCategoryId, SUM(orders.TotalValue) AS TotalSum FROM users LEFT JOIN orders ON users.UserId = orders.UserId LEFT JOIN products ON orders.ProductId = products.ProductId LEFT JOIN categories ON products.CategoryId = categories.CategoryId GROUP BY users.UserId, categories.CategoryId ORDER BY ConsideredUserId ASC, TotalSum DESC")
+    val groupedByUsersAndCategoriesDF = spark.sql(
+      """
+        |SELECT users.UserId AS ConsideredUserId, categories.CategoryId AS ConsideredCategoryId, SUM(orders.TotalValue) AS TotalSum
+        |FROM users
+        |LEFT JOIN orders ON users.UserId = orders.UserId
+        |LEFT JOIN products ON orders.ProductId = products.ProductId
+        |LEFT JOIN categories ON products.CategoryId = categories.CategoryId
+        |GROUP BY users.UserId, categories.CategoryId
+        |ORDER BY ConsideredUserId ASC, TotalSum DESC""".stripMargin
+    )
 
     // groupedByUsersAndCategoriesDF.explain()
 

--- a/src/main/scala/example/Task1RepartitioningApproach.scala
+++ b/src/main/scala/example/Task1RepartitioningApproach.scala
@@ -7,12 +7,13 @@ object Task1RepartitioningApproach {
   // QUERY: Find spendings (both already paid or not) of different users on products from different categories.
 
   def transformationTask1WithRepartitioningApproach(
-      spark: SparkSession,
       notCompletedOrdersDF: DataFrame,
       completedOrdersDF: DataFrame,
       usersDF: DataFrame,
       productsDF: DataFrame,
       categoriesDF: DataFrame
+    )(
+      implicit spark: SparkSession
     ): DataFrame = {
     usersDF
       .repartition(col("UserId"))

--- a/src/main/scala/example/Task1SimpleApproach.scala
+++ b/src/main/scala/example/Task1SimpleApproach.scala
@@ -24,7 +24,16 @@ object Task1SimpleApproach {
       .union(notCompletedOrdersDF)
       .createOrReplaceTempView("orders")
 
-    val groupedByUsersAndCategoriesDF = spark.sql("SELECT users.UserId AS ConsideredUserId, categories.CategoryId AS ConsideredCategoryId, SUM(orders.TotalValue) AS TotalSum FROM users LEFT JOIN orders ON users.UserId = orders.UserId LEFT JOIN products ON orders.ProductId = products.ProductId LEFT JOIN categories ON products.CategoryId = categories.CategoryId GROUP BY users.UserId, categories.CategoryId ORDER BY ConsideredUserId ASC, TotalSum DESC")
+    val groupedByUsersAndCategoriesDF = spark.sql(
+      """
+        |SELECT users.UserId AS ConsideredUserId, categories.CategoryId AS ConsideredCategoryId, SUM(orders.TotalValue) AS TotalSum
+        |FROM users
+        |LEFT JOIN orders ON users.UserId = orders.UserId
+        |LEFT JOIN products ON orders.ProductId = products.ProductId
+        |LEFT JOIN categories ON products.CategoryId = categories.CategoryId
+        |GROUP BY users.UserId, categories.CategoryId
+        |ORDER BY ConsideredUserId ASC, TotalSum DESC""".stripMargin
+    )
 
     // groupedByUsersAndCategoriesDF.explain()
 

--- a/src/main/scala/example/Task1SimpleApproach.scala
+++ b/src/main/scala/example/Task1SimpleApproach.scala
@@ -2,9 +2,22 @@ package example
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
+/** Represents an algorithm for Task 1, simple approach.
+ *  QUERY: Find spendings (both already paid or not) of different users on products from different categories.
+ */
+
 object Task1SimpleApproach {
   // QUERY: Find spendings (both already paid or not) of different users on products from different categories.
 
+  /** An algorithm for Task 1, simple approach
+   *
+   * @param notCompletedOrdersDF set of not completed orders
+   * @param completedOrdersDF set of completed orders
+   * @param usersDF set of users
+   * @param productsDF set of products
+   * @param categoriesDF set of categories
+   * @return Spendings (both already paid or not) of different users on products from different categories.
+   */
   def transformationTask1WithSimpleApproach(
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,

--- a/src/main/scala/example/Task1SimpleApproach.scala
+++ b/src/main/scala/example/Task1SimpleApproach.scala
@@ -9,8 +9,6 @@ object Task1SimpleApproach {
     spark: SparkSession,
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,
-    notCompletedPaymentsDF: DataFrame,
-    completedPaymentsDF: DataFrame,
     usersDF: DataFrame,
     productsDF: DataFrame,
     categoriesDF: DataFrame
@@ -21,14 +19,7 @@ object Task1SimpleApproach {
       .createOrReplaceTempView("products")
     categoriesDF
       .createOrReplaceTempView("categories")
-//  completedPaymentsDF
-//    .createOrReplaceTempView("completed_payments")
-//  notCompletedPaymentsDF
-//    .createOrReplaceTempView("not_completed_payments")
-//  completedOrdersDF
-//    .createOrReplaceTempView("completed_orders")
-//  notCompletedOrdersDF
-//    .createOrReplaceTempView("not_completed_orders")
+
     completedOrdersDF
       .union(notCompletedOrdersDF)
       .createOrReplaceTempView("orders")
@@ -68,8 +59,6 @@ object Task1SimpleApproach {
     //            +- Sort [CategoryId#148 ASC NULLS FIRST], false, 0
     //               +- Exchange hashpartitioning(CategoryId#148, 200), ENSURE_REQUIREMENTS, [plan_id=89]
     //                  +- LocalTableScan [CategoryId#148]
-
-    // groupedByUsersAndCategoriesDF.show()
 
     groupedByUsersAndCategoriesDF
   }

--- a/src/main/scala/example/Task1SimpleApproach.scala
+++ b/src/main/scala/example/Task1SimpleApproach.scala
@@ -6,12 +6,13 @@ object Task1SimpleApproach {
   // QUERY: Find spendings (both already paid or not) of different users on products from different categories.
 
   def transformationTask1WithSimpleApproach(
-    spark: SparkSession,
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,
     usersDF: DataFrame,
     productsDF: DataFrame,
     categoriesDF: DataFrame
+  )(
+    implicit spark: SparkSession,
   ): DataFrame = {
     usersDF
       .createOrReplaceTempView("users")

--- a/src/main/scala/example/Task1SimpleApproachWithComplications.scala
+++ b/src/main/scala/example/Task1SimpleApproachWithComplications.scala
@@ -10,8 +10,6 @@ object Task1SimpleApproachWithComplications {
     spark: SparkSession,
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,
-    notCompletedPaymentsDF: DataFrame,
-    completedPaymentsDF: DataFrame,
     usersDF: DataFrame,
     productsDF: DataFrame,
     categoriesDF: DataFrame,
@@ -23,14 +21,7 @@ object Task1SimpleApproachWithComplications {
       .createOrReplaceTempView("products")
     categoriesDF
       .createOrReplaceTempView("categories")
-//  completedPaymentsDF
-//    .createOrReplaceTempView("completed_payments")
-//  notCompletedPaymentsDF
-//    .createOrReplaceTempView("not_completed_payments")
-//  completedOrdersDF
-//    .createOrReplaceTempView("completed_orders")
-//  notCompletedOrdersDF
-//    .createOrReplaceTempView("not_completed_orders")
+
     completedOrdersDF
       .union(notCompletedOrdersDF)
       .createOrReplaceTempView("orders")
@@ -71,8 +62,6 @@ object Task1SimpleApproachWithComplications {
     //              +- Sort [CategoryId#148 ASC NULLS FIRST], false, 0
     //                 +- Exchange hashpartitioning(CategoryId#148, 200), ENSURE_REQUIREMENTS, [plan_id=89]
     //                    +- LocalTableScan [CategoryId#148]
-
-    // groupedByUsersAndCategoriesDF.show()
 
     groupedByUsersAndCategoriesDF
   }

--- a/src/main/scala/example/Task1SimpleApproachWithComplications.scala
+++ b/src/main/scala/example/Task1SimpleApproachWithComplications.scala
@@ -26,8 +26,17 @@ object Task1SimpleApproachWithComplications {
       .union(notCompletedOrdersDF)
       .createOrReplaceTempView("orders")
 
-    val startDateWithQuotationMarks = "\"" + startDate + "\""
-    val groupedByUsersAndCategoriesDF = spark.sql("SELECT users.UserId AS ConsideredUserId, CONCAT(UPPER(users.FirstName), ' ', UPPER(users.LastName)) AS ConsideredFullNameInUpperCase, categories.CategoryId AS ConsideredCategoryId, SUM(orders.TotalValue) AS TotalSum FROM users LEFT JOIN orders ON users.UserId = orders.UserId LEFT JOIN products ON orders.ProductId = products.ProductId LEFT JOIN categories ON products.CategoryId = categories.CategoryId WHERE CAST(SPLIT(orders.OrderGenerationDate, \" \")[0] AS DATE) > " + startDateWithQuotationMarks + " GROUP BY users.UserId, users.FirstName, users.LastName, categories.CategoryId ORDER BY ConsideredUserId ASC, TotalSum DESC")
+    val groupedByUsersAndCategoriesDF = spark.sql(
+      s"""
+        |SELECT users.UserId AS ConsideredUserId, CONCAT(UPPER(users.FirstName), ' ', UPPER(users.LastName)) AS ConsideredFullNameInUpperCase, categories.CategoryId AS ConsideredCategoryId, SUM(orders.TotalValue) AS TotalSum
+        |FROM users
+        |LEFT JOIN orders ON users.UserId = orders.UserId
+        |LEFT JOIN products ON orders.ProductId = products.ProductId
+        |LEFT JOIN categories ON products.CategoryId = categories.CategoryId
+        |WHERE CAST(SPLIT(orders.OrderGenerationDate, \" \")[0] AS DATE) > \"$startDate\"
+        |GROUP BY users.UserId, users.FirstName, users.LastName, categories.CategoryId
+        |ORDER BY ConsideredUserId ASC, TotalSum DESC""".stripMargin
+    )
 
     // groupedByUsersAndCategoriesDF.explain()
 

--- a/src/main/scala/example/Task1SimpleApproachWithComplications.scala
+++ b/src/main/scala/example/Task1SimpleApproachWithComplications.scala
@@ -7,13 +7,14 @@ object Task1SimpleApproachWithComplications {
   //        Do not consider orders older than a specific day. Each user ID should be accompanied by first name and last name in uppercase.
 
   def transformationTask1WithSimpleApproachWithComplications(
-    spark: SparkSession,
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,
     usersDF: DataFrame,
     productsDF: DataFrame,
     categoriesDF: DataFrame,
     startDate: String
+  )(
+    implicit spark: SparkSession,
   ): DataFrame = {
     usersDF
       .createOrReplaceTempView("users")

--- a/src/main/scala/example/Task1SimpleApproachWithComplications.scala
+++ b/src/main/scala/example/Task1SimpleApproachWithComplications.scala
@@ -2,10 +2,24 @@ package example
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
+/** Represents an algorithm for Task 1, simple approach with "complications".
+ *  QUERY: Find spendings (both already paid or not) of different users on products from different categories.
+ *         Do not consider orders older than a specific day. Each user ID should be accompanied by first name and last name in uppercase.
+ */
+
 object Task1SimpleApproachWithComplications {
   // QUERY: Find spendings (both already paid or not) of different users on products from different categories.
   //        Do not consider orders older than a specific day. Each user ID should be accompanied by first name and last name in uppercase.
 
+  /** An algorithm for Task 1, simple approach with "complications"
+   *
+   * @param notCompletedOrdersDF set of not completed orders
+   * @param completedOrdersDF set of completed orders
+   * @param usersDF set of users
+   * @param productsDF set of products
+   * @param categoriesDF set of categories
+   * @return Spendings (both already paid or not) of different users on products from different categories. Do not consider orders older than a specific day. Each user ID should be accompanied by first name and last name in uppercase.
+   */
   def transformationTask1WithSimpleApproachWithComplications(
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,

--- a/src/main/scala/example/Task2RepartitioningApproach.scala
+++ b/src/main/scala/example/Task2RepartitioningApproach.scala
@@ -3,7 +3,22 @@ package example
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{asc, col, desc, sum}
 
+/** Represents an algorithm for Task 2, repartition-based approach.
+ *  QUERY: Find spendings (both already paid or not) of different users on products from different categories.
+ */
+
 object Task2RepartitioningApproach {
+  // QUERY: Find spendings (both already paid or not) of different users on products from different categories.
+
+  /** An algorithm for Task 2, repartition-based approach
+   *
+   * @param notCompletedOrdersDF set of not completed orders
+   * @param completedOrdersDF set of completed orders
+   * @param usersDF set of users
+   * @param productsDF set of products
+   * @param categoriesDF set of categories
+   * @return Spendings (both already paid or not) of different users on products from different categories.
+   */
   def transformationTask2WithRepartitioningApproach(
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,

--- a/src/main/scala/example/Task2RepartitioningApproach.scala
+++ b/src/main/scala/example/Task2RepartitioningApproach.scala
@@ -1,45 +1,36 @@
 package example
 
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{asc, col, desc, sum}
 
 object Task2RepartitioningApproach {
   def transformationTask2WithRepartitioningApproach(
-    spark: SparkSession,
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,
-    notCompletedPaymentsDF: DataFrame,
-    completedPaymentsDF: DataFrame,
     usersDF: DataFrame,
     productsDF: DataFrame,
     categoriesDF: DataFrame
   ): DataFrame = {
     val preprocessedNotCompletedOrdersDF = notCompletedOrdersDF
       .repartition(col("UserId"))
-    // .select(col("OrderId"), col("TotalValue"), col("UserId"), col("ProductId"))
+
     val preprocessedCompletedOrdersDF = completedOrdersDF
       .repartition(col("UserId"))
-    // .select(col("OrderId"), col("TotalValue"), col("UserId"), col("ProductId"))
+
     val preprocessedUsersDF = usersDF
       .repartition(col("UserId"))
-    // .select(col("UserId"))
+
     val preprocessedProductsDF = productsDF
       .repartition(col("CategoryId"))
-    // .select(col("ProductId"), col("CategoryId"))
+
     val preprocessedCategoriesDF = categoriesDF
       .repartition(col("CategoryId"))
-    // .select(col("CategoryId"))
 
     val preprocessedOrdersDF = preprocessedNotCompletedOrdersDF.union(preprocessedCompletedOrdersDF)
-    // preprocessedOrdersDF.printSchema()
 
     val usersJoinedWithOrdersDF = preprocessedUsersDF.join(preprocessedOrdersDF, preprocessedUsersDF.col("UserId") === preprocessedOrdersDF.col("UserId"), "left")
-    // usersJoinedWithOrdersDF.printSchema()
     val productsJoinedWithCategoriesDF = preprocessedProductsDF.join(preprocessedCategoriesDF, preprocessedProductsDF.col("CategoryId") === preprocessedCategoriesDF.col("CategoryId"), "left")
-    // productsJoinedCategoriesDF.printSchema()
-
     val usersJoinedWithOrdersProductsAndCategoriesDF = usersJoinedWithOrdersDF.join(productsJoinedWithCategoriesDF, preprocessedOrdersDF.col("ProductId") === preprocessedProductsDF.col("ProductId"), "left")
-    // usersJoinedWithOrdersProductsAndCategoriesDF.printSchema()
 
     val groupedByUsersAndCategoriesDF = usersJoinedWithOrdersProductsAndCategoriesDF
       .groupBy(
@@ -88,31 +79,6 @@ object Task2RepartitioningApproach {
     //                      +- Sort [CategoryId#148 ASC NULLS FIRST], false, 0
     //                         +- Exchange hashpartitioning(CategoryId#148, 200), REPARTITION_BY_COL, [plan_id=70] // REPARTITION CATEGORIES BY CATEGORY ID
     //                            +- LocalTableScan [CategoryId#148] // LOAD CATEGORIES
-
-    // WITHOUT "COMPLICATIONS"
-    // PERFORMANCE TEST
-
-    //  val COMPLETED_ORDERS_COUNT = 50000
-    //  val NOT_COMPLETED_ORDERS_COUNT = 50000
-    //  val USERS_COUNT = 10000
-    //  val INSTANCES_COUNT = 5
-    //  val COUNTRIES_COUNT = 10
-    //  val MANUFACTURERS_COUNT = 20
-    //  val PRODUCTS_COUNT = 1000
-    //  val CATEGORIES_COUNT = 100
-    //
-    //  val PRICE_INTERVAL = 100
-    //  val MAX_PRICE = 500
-    //
-    //  val WEIGHT_INTERVAL = 20
-    //  val MAX_WEIGHT = 100
-    //
-    //  val MAX_DAYS = 28
-
-    // Around 6s, the effort is moved from the end to the beginning of computations. Repartitioning is approximately as costly as a shuffle.
-    // For a bigger number of joins using the same partitioning columns it can pays off - it will be done once at the beginning.
-
-    // groupedByUsersAndCategoriesDF.show()
 
     groupedByUsersAndCategoriesDF
   }

--- a/src/main/scala/example/Task2SimpleApproach.scala
+++ b/src/main/scala/example/Task2SimpleApproach.scala
@@ -3,9 +3,22 @@ package example
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{asc, desc, sum}
 
+/** Represents an algorithm for Task 2, simple approach.
+ *  QUERY: Find spendings (both already paid or not) of different users on products from different categories.
+ */
+
 object Task2SimpleApproach {
   // QUERY: Find spendings (both already paid or not) of different users on products from different categories.
 
+  /** An algorithm for Task 2, simple approach
+   *
+   * @param notCompletedOrdersDF set of not completed orders
+   * @param completedOrdersDF set of completed orders
+   * @param usersDF set of users
+   * @param productsDF set of products
+   * @param categoriesDF set of categories
+   * @return Spendings (both already paid or not) of different users on products from different categories.
+   */
   def transformationTask2WithSimpleApproach(
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,

--- a/src/main/scala/example/Task2SimpleApproach.scala
+++ b/src/main/scala/example/Task2SimpleApproach.scala
@@ -1,34 +1,24 @@
 package example
 
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{asc, desc, sum}
 
 object Task2SimpleApproach {
   // QUERY: Find spendings (both already paid or not) of different users on products from different categories.
 
   def transformationTask2WithSimpleApproach(
-    spark: SparkSession,
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,
-    notCompletedPaymentsDF: DataFrame,
-    completedPaymentsDF: DataFrame,
     usersDF: DataFrame,
     productsDF: DataFrame,
     categoriesDF: DataFrame
   ): DataFrame = {
     val ordersDF = notCompletedOrdersDF
       .union(completedOrdersDF)
-    // ordersDF.printSchema()
-    // val paymentsDF = notCompletedPaymentsDF
-    //   .union(completedPaymentsDF)
-    // paymentsDF.printSchema()
 
     val usersJoinedWithOrdersDF = usersDF.join(ordersDF, usersDF.col("UserId") === ordersDF.col("UserId"), "left")
-    // usersJoinedWithOrdersDF.printSchema()
     val usersJoinedWithOrdersAndProductsDF = usersJoinedWithOrdersDF.join(productsDF, ordersDF.col("ProductId") === productsDF.col("ProductId"), "left")
-    // usersJoinedWithOrdersAndProductsDF.printSchema()
     val usersJoinedWithOrdersProductsAndCategoriesDF = usersJoinedWithOrdersAndProductsDF.join(categoriesDF, productsDF.col("CategoryId") === categoriesDF.col("CategoryId"), "left")
-    // usersJoinedWithOrdersProductsAndCategoriesDF.printSchema()
 
     val groupedByUsersAndCategoriesDF = usersJoinedWithOrdersProductsAndCategoriesDF
       .groupBy(
@@ -101,30 +91,6 @@ object Task2SimpleApproach {
     //                  +- Sort [CategoryId#148 ASC NULLS FIRST], false, 0 // PREPARATION FOR JOIN OF USERS ORDERS PRODUCTS AND CATEGORIES
     //                    +- Exchange hashpartitioning(CategoryId#148, 200), ENSURE_REQUIREMENTS, [plan_id=77]
     //                      +- LocalTableScan [CategoryId#148] // LOAD CATEGORIES
-
-    // groupedByUsersAndCategoriesDF.show()
-
-    // WITHOUT "COMPLICATIONS"
-    // PERFORMANCE TEST
-
-    //  val COMPLETED_ORDERS_COUNT = 50000
-    //  val NOT_COMPLETED_ORDERS_COUNT = 50000
-    //  val USERS_COUNT = 10000
-    //  val INSTANCES_COUNT = 5
-    //  val COUNTRIES_COUNT = 10
-    //  val MANUFACTURERS_COUNT = 20
-    //  val PRODUCTS_COUNT = 1000
-    //  val CATEGORIES_COUNT = 100
-    //
-    //  val PRICE_INTERVAL = 100
-    //  val MAX_PRICE = 500
-    //
-    //  val WEIGHT_INTERVAL = 20
-    //  val MAX_WEIGHT = 100
-    //
-    //  val MAX_DAYS = 28
-
-    // Around 6s, not worse than without the repartitioning.
 
     groupedByUsersAndCategoriesDF
   }

--- a/src/main/scala/example/Task2SimpleApproachWithComplications.scala
+++ b/src/main/scala/example/Task2SimpleApproachWithComplications.scala
@@ -8,11 +8,8 @@ object Task2SimpleApproachWithComplications {
   //        Do not consider orders older than a specific day. Each user ID should be accompanied by first name and last name in uppercase.
 
   def transformationTask2WithSimpleApproachWithComplications(
-    spark: SparkSession,
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,
-    notCompletedPaymentsDF: DataFrame,
-    completedPaymentsDF: DataFrame,
     usersDF: DataFrame,
     productsDF: DataFrame,
     categoriesDF: DataFrame,
@@ -20,10 +17,6 @@ object Task2SimpleApproachWithComplications {
   ): DataFrame = {
     val ordersDF = notCompletedOrdersDF
       .union(completedOrdersDF)
-    // ordersDF.printSchema()
-    // val paymentsDF = notCompletedPaymentsDF
-    //   .union(completedPaymentsDF)
-    // paymentsDF.printSchema()
 
     val modifiedUsersDF = usersDF
       .withColumn("FullNameInUpperCase", concat(upper(usersDF.col("FirstName")), lit(" "), upper(usersDF.col("LastName"))))
@@ -33,11 +26,8 @@ object Task2SimpleApproachWithComplications {
       .filter(col("ParsedOrderGenerationDate") > startDate)
 
     val usersJoinedWithOrdersDF = modifiedUsersDF.join(modifiedOrdersDF, modifiedUsersDF.col("UserId") === modifiedOrdersDF.col("UserId"), "left")
-    // usersJoinedWithOrdersDF.printSchema()
     val usersJoinedWithOrdersAndProductsDF = usersJoinedWithOrdersDF.join(productsDF, modifiedOrdersDF.col("ProductId") === productsDF.col("ProductId"), "left")
-    // usersJoinedWithOrdersAndProductsDF.printSchema()
     val usersJoinedWithOrdersProductsAndCategoriesDF = usersJoinedWithOrdersAndProductsDF.join(categoriesDF, productsDF.col("CategoryId") === categoriesDF.col("CategoryId"), "left")
-    // usersJoinedWithOrdersProductsAndCategoriesDF.printSchema()
 
     val groupedByUsersAndCategoriesDF = usersJoinedWithOrdersProductsAndCategoriesDF
       .groupBy(
@@ -84,8 +74,6 @@ object Task2SimpleApproachWithComplications {
     //            +- Sort [CategoryId#148 ASC NULLS FIRST], false, 0
     //               +- Exchange hashpartitioning(CategoryId#148, 200), ENSURE_REQUIREMENTS, [plan_id=77]
     //                  +- LocalTableScan [CategoryId#148]
-
-    // groupedByUsersAndCategoriesDF.show()
 
     groupedByUsersAndCategoriesDF
   }

--- a/src/main/scala/example/Task2SimpleApproachWithComplications.scala
+++ b/src/main/scala/example/Task2SimpleApproachWithComplications.scala
@@ -1,12 +1,26 @@
 package example
 
 import org.apache.spark.sql.functions.{asc, col, concat, desc, lit, split, sum, to_date, upper}
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.DataFrame
+
+/** Represents an algorithm for Task 2, simple approach with "complications".
+ *  QUERY: Find spendings (both already paid or not) of different users on products from different categories.
+ *         Do not consider orders older than a specific day. Each user ID should be accompanied by first name and last name in uppercase.
+ */
 
 object Task2SimpleApproachWithComplications {
   // QUERY: Find spendings (both already paid or not) of different users on products from different categories.
   //        Do not consider orders older than a specific day. Each user ID should be accompanied by first name and last name in uppercase.
 
+  /** An algorithm for Task 2, simple approach with "complications"
+   *
+   * @param notCompletedOrdersDF set of not completed orders
+   * @param completedOrdersDF set of completed orders
+   * @param usersDF set of users
+   * @param productsDF set of products
+   * @param categoriesDF set of categories
+   * @return Spendings (both already paid or not) of different users on products from different categories. Do not consider orders older than a specific day. Each user ID should be accompanied by first name and last name in uppercase.
+   */
   def transformationTask2WithSimpleApproachWithComplications(
     notCompletedOrdersDF: DataFrame,
     completedOrdersDF: DataFrame,

--- a/src/main/scala/example/TaskData.scala
+++ b/src/main/scala/example/TaskData.scala
@@ -116,7 +116,7 @@ object TaskData {
 
   // CREATE DYNAMICALLY GENERATED DATAFRAMES
 
-  def createDynamicallyGeneratedSampleUsersDF(spark: SparkSession): DataFrame = {
+  def createDynamicallyGeneratedSampleUsersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createDynamicallyGeneratedSampleUsers(USERS_COUNT))
       .withColumnRenamed("_1", "UserId")
       .withColumnRenamed("_2", "FirstName")
@@ -127,7 +127,7 @@ object TaskData {
       .withColumnRenamed("_7", "Address")
   }
 
-  def createDynamicallyGeneratedSampleCompletedOrdersDF(spark: SparkSession): DataFrame = {
+  def createDynamicallyGeneratedSampleCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createDynamicallyGeneratedSampleCompletedOrders(COMPLETED_ORDERS_COUNT))
       .withColumnRenamed("_1", "OrderId")
       .withColumnRenamed("_2", "PaymentId")
@@ -142,7 +142,7 @@ object TaskData {
       .withColumnRenamed("_11", "Status")
   }
 
-  def createDynamicallyGeneratedSampleNotCompletedOrdersDF(spark: SparkSession): DataFrame = {
+  def createDynamicallyGeneratedSampleNotCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createDynamicallyGeneratedSampleNotCompletedOrders(NOT_COMPLETED_ORDERS_COUNT))
       .withColumnRenamed("_1", "OrderId")
       .withColumnRenamed("_2", "PaymentId")
@@ -157,7 +157,7 @@ object TaskData {
       .withColumnRenamed("_11", "Status")
   }
 
-  def createDynamicallyGeneratedSampleProductsDF(spark: SparkSession): DataFrame = {
+  def createDynamicallyGeneratedSampleProductsDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createDynamicallyGeneratedSampleProducts(PRODUCTS_COUNT))
       .withColumnRenamed("_1", "ProductId")
       .withColumnRenamed("_2", "CategoryId")
@@ -168,7 +168,7 @@ object TaskData {
       .withColumnRenamed("_7", "MarketEntranceDate")
   }
 
-  def createDynamicallyGeneratedSampleCategoriesDF(spark: SparkSession): DataFrame = {
+  def createDynamicallyGeneratedSampleCategoriesDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createDynamicallyGeneratedSampleCategories(CATEGORIES_COUNT))
       .withColumnRenamed("_1", "CategoryId")
       .withColumnRenamed("_2", "Name")
@@ -178,7 +178,7 @@ object TaskData {
 
   // CREATE STATICALLY GENERATED DATAFRAMES
 
-  def createSampleUsersDF(spark: SparkSession): DataFrame = {
+  def createSampleUsersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleUsers)
       .withColumnRenamed("_1", "UserId")
       .withColumnRenamed("_2", "FirstName")
@@ -189,7 +189,7 @@ object TaskData {
       .withColumnRenamed("_7", "Address")
   }
 
-  def createSampleCompletedOrdersDF(spark: SparkSession): DataFrame = {
+  def createSampleCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleCompletedOrders)
       .withColumnRenamed("_1", "OrderId")
       .withColumnRenamed("_2", "PaymentId")
@@ -204,7 +204,7 @@ object TaskData {
       .withColumnRenamed("_11", "Status")
   }
 
-  def createSampleNotCompletedOrdersDF(spark: SparkSession): DataFrame = {
+  def createSampleNotCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleNotCompletedOrders)
       .withColumnRenamed("_1", "OrderId")
       .withColumnRenamed("_2", "PaymentId")
@@ -219,7 +219,7 @@ object TaskData {
       .withColumnRenamed("_11", "Status")
   }
 
-  def createSampleProductsDF(spark: SparkSession): DataFrame = {
+  def createSampleProductsDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleProducts)
       .withColumnRenamed("_1", "ProductId")
       .withColumnRenamed("_2", "CategoryId")
@@ -230,7 +230,7 @@ object TaskData {
       .withColumnRenamed("_7", "MarketEntranceDate")
   }
 
-  def createSampleCategoriesDF(spark: SparkSession): DataFrame = {
+  def createSampleCategoriesDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleCategories)
       .withColumnRenamed("_1", "CategoryId")
       .withColumnRenamed("_2", "Name")
@@ -238,7 +238,7 @@ object TaskData {
       .withColumnRenamed("_4", "Country")
   }
 
-  def createSampleCompletedPaymentsDF(spark: SparkSession): DataFrame = {
+  def createSampleCompletedPaymentsDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleCompletedPayments)
       .withColumnRenamed("_1", "PaymentId")
       .withColumnRenamed("_2", "Country")
@@ -248,7 +248,7 @@ object TaskData {
       .withColumnRenamed("_6", "PaymentStatus")
   }
 
-  def createSampleNotCompletedPaymentsDF(spark: SparkSession): DataFrame = {
+  def createSampleNotCompletedPaymentsDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleNotCompletedPayments)
       .withColumnRenamed("_1", "PaymentId")
       .withColumnRenamed("_2", "Country")

--- a/src/main/scala/example/TaskData.scala
+++ b/src/main/scala/example/TaskData.scala
@@ -2,6 +2,10 @@ package example
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
+/** Represents all statically and dynamically generated test data.
+ *
+ */
+
 object TaskData {
   val COMPLETED_ORDERS_COUNT = 50000
   val NOT_COMPLETED_ORDERS_COUNT = 50000
@@ -28,44 +32,105 @@ object TaskData {
   //       However, it should not matter too much for performance testing.
   //       The code may contain some bugs.
 
+  /** User tuple generated dynamically for Test purposes.
+   * @param id - id of the generated instance
+   * @return User tuple.
+   */
   def createDynamicallyGeneratedSampleUser(id: Int): (String, String, String, String, String, String, String) =
     (s"user-$id", s"FirstName-$id", s"LastName-$id", s"Country-${id % COUNTRIES_COUNT + 1}", s"City-$id", s"PostalCode-$id", s"Address-$id")
 
+  /** Seq with user tuples generated dynamically for Test purposes.
+   *
+   * @param count - number of generated instances
+   * @return Seq with user tuples.
+   */
   def createDynamicallyGeneratedSampleUsers(count: Int): Seq[(String, String, String, String, String, String, String)] =
     (1 to count).map(i => createDynamicallyGeneratedSampleUser(i)).toList
 
+  /** Product tuple generated dynamically for Test purposes.
+   *
+   * @param id - id of the generated instance
+   * @return Product tuple.
+   */
   def createDynamicallyGeneratedSampleProduct(id: Int): (String, String, String, String, Double, Double, String) =
     (s"product-$id", s"category-${id % CATEGORIES_COUNT + 1}", s"Manufacturer-${id % MANUFACTURERS_COUNT + 1}", s"Country-${id % COUNTRIES_COUNT + 1}", id * PRICE_INTERVAL % MAX_PRICE + PRICE_INTERVAL, id * WEIGHT_INTERVAL % MAX_WEIGHT + WEIGHT_INTERVAL, f"2023-01-${id % MAX_DAYS + 1}%02d")
 
+  /** Seq with product tuples generated dynamically for Test purposes.
+   *
+   * @param count - number of generated instances
+   * @return Seq with product tuples.
+   */
   def createDynamicallyGeneratedSampleProducts(count: Int): Seq[(String, String, String, String, Double, Double, String)] =
     (1 to count).map(i => createDynamicallyGeneratedSampleProduct(i)).toList
 
+  /** Category tuple generated dynamically for Test purposes.
+   *
+   * @param id - id of the generated instance
+   * @return Category tuple.
+   */
   def createDynamicallyGeneratedSampleCategory(id: Int): (String, String, String, String) =
     (s"category-$id", s"Name-$id", s"Code-$id", s"Country-${id % COUNTRIES_COUNT + 1}")
 
+  /** Seq with category tuples generated dynamically for Test purposes.
+   *
+   * @param count - number of generated instances
+   * @return Seq with category tuples.
+   */
   def createDynamicallyGeneratedSampleCategories(count: Int): Seq[(String, String, String, String)] =
     (1 to count).map(i => createDynamicallyGeneratedSampleCategory(i)).toList
 
+  /** Completed order tuple generated dynamically for Test purposes.
+   *
+   * @param id - id of the generated instance
+   * @param price - price of the generated instance
+   * @param weight - weight of the generated instance
+   * @return Completed order tuple.
+   */
   def createDynamicallyGeneratedSampleCompletedOrder(id: Int, price: Double, weight: Double): (String, String, String, String, String, Long, Double, Double, String, String, String) =
     (s"order-$id", s"payment-$id", s"user-${id % USERS_COUNT + 1}", s"product-${id % PRODUCTS_COUNT + 1}", s"Country-${id % COUNTRIES_COUNT}", id % INSTANCES_COUNT + 1, price * (id % INSTANCES_COUNT + 1), weight * (id % INSTANCES_COUNT + 1), f"2023-02-${id % MAX_DAYS + 1}%02d 00:00:00", f"2023-03-${id % MAX_DAYS + 1}%02d 00:00:00", "COMPLETED")
 
+  /** Not completed order tuple generated dynamically for Test purposes.
+   *
+   * @param id - id of the generated instance
+   * @param price - price of the generated instance
+   * @param weight - weight of the generated instance
+   * @return Not completed order tuple.
+   */
   def createDynamicallyGeneratedSampleNotCompletedOrder(id: Int, price: Double, weight: Double): (String, String, String, String, String, Long, Double, Double, String, String, String) =
     (s"order-$id", s"payment-$id", s"user-${id % USERS_COUNT + 1}", s"product-${id % PRODUCTS_COUNT + 1}", s"Country-${id % COUNTRIES_COUNT}", id % INSTANCES_COUNT + 1, price * (id % INSTANCES_COUNT + 1), weight * (id % INSTANCES_COUNT + 1), f"2023-02-${id % MAX_DAYS + 1}%02d 00:00:00", s"", "NOT_COMPLETED")
 
+  /** Seq with completed order tuples generated dynamically for Test purposes.
+   *
+   * @param count - number of generated instances
+   * @return Seq with completed order tuples.
+   */
   def createDynamicallyGeneratedSampleCompletedOrders(count: Int): Seq[(String, String, String, String, String, Long, Double, Double, String, String, String)] =
     (1 to count).map(i => createDynamicallyGeneratedSampleCompletedOrder(i, i * PRICE_INTERVAL % MAX_PRICE + PRICE_INTERVAL, i * WEIGHT_INTERVAL % MAX_WEIGHT + WEIGHT_INTERVAL)).toList
 
+  /** Seq with not completed order tuples generated dynamically for Test purposes.
+   *
+   * @param count - number of generated instances
+   * @return Seq with not completed order tuples.
+   */
   def createDynamicallyGeneratedSampleNotCompletedOrders(count: Int): Seq[(String, String, String, String, String, Long, Double, Double, String, String, String)] =
     (1 to count).map(i => createDynamicallyGeneratedSampleNotCompletedOrder(i, i * PRICE_INTERVAL % MAX_PRICE + PRICE_INTERVAL, i * WEIGHT_INTERVAL % MAX_WEIGHT + WEIGHT_INTERVAL)).toList
 
   // STATICALLY GENERATED
 
+  /** Seq with users generated statically for Test purposes.
+   *
+   * @return Seq with users.
+   */
   def createSampleUsers: Seq[(String, String, String, String, String, String, String)] = List(
     ("user-01", "Anne", "Anderson", "USA", "Boston", "02138", "19 Ware St, Cambridge, MA 02138, USA"),
     ("user-02", "Tommy", "Harada", "Japan", "Ebina", "243-0402", "555-1 Kashiwagaya, Ebina, Kanagawa 243-0402, Japan"),
     ("user-03", "Stephane", "Moreau", "France", "Paris", "75003", "14 R. des Minimes, 75003 Paris, France")
   )
 
+  /** Seq with completed orders generated statically for Test purposes.
+   *
+   * @return Seq with completed orders.
+   */
   def createSampleCompletedOrders: Seq[(String, String, String, String, String, Long, Double, Double, String, String, String)] = Seq(
     ("order-01", "payment-01", "user-01", "laptop-01", "USA", 1L, 100.0, 20.0, "2023-02-01 00:00:00", "2023-02-09 00:00:00", "COMPLETED"),
     ("order-02", "payment-02", "user-02", "laptop-02", "Japan", 2L, 400.0, 80.0, "2023-03-01 00:00:00", "2023-03-09 00:00:00", "COMPLETED"),
@@ -73,11 +138,19 @@ object TaskData {
     ("order-04", "payment-04", "user-01", "laptop-05", "USA", 2L, 500.0, 20.0, "2023-05-01 00:00:00", "2023-05-09 00:00:00", "COMPLETED")
   )
 
+  /** Seq with not completed orders generated statically for Test purposes.
+   *
+   * @return Seq with not completed orders.
+   */
   def createSampleNotCompletedOrders: Seq[(String, String, String, String, String, Long, Double, Double, String, String, String)] = Seq(
     ("order-05", "payment-05", "user-02", "laptop-06", "Japan", 1L, 350.0, 40.0, "2023-07-01 00:00:00", "", "NOT COMPLETED"),
     ("order-06", "payment-06", "user-03", "laptop-07", "France", 2L, 200.0, 160.0, "2023-07-01 00:00:00", "", "NOT COMPLETED")
   )
 
+  /** Seq with products generated statically for Test purposes.
+   *
+   * @return Seq with products.
+   */
   def createSampleProducts: Seq[(String, String, String, String, Double, Double, String)] = Seq(
     ("laptop-01", "office-laptops-01", "HP", "USA", 100.0, 20.0, "2023-01-01"),
     ("laptop-02", "regular-laptops-01", "Dell", "Japan", 200.0, 40.0, "2023-02-01"),
@@ -91,6 +164,10 @@ object TaskData {
     ("laptop-10", "gaming-laptops-01", "Asus", "USA", 100.0, 40.0, "2023-01-01")
   )
 
+  /** Seq with categories generated statically for Test purposes.
+   *
+   * @return Seq with categories.
+   */
   def createSampleCategories: Seq[(String, String, String, String)] = Seq(
     ("office-laptops-01", "office-laptops", "ol-01", "USA"),
     ("gaming-laptops-01", "gaming-laptops", "gl-01", "USA"),
@@ -102,6 +179,10 @@ object TaskData {
     ("ultra-laptops-02", "ultra-laptops", "ul-02", "Germany")
   )
 
+  /** Seq with completed payments generated statically for Test purposes.
+   *
+   * @return Seq with completed payments.
+   */
   def createSampleCompletedPayments: Seq[(String, String, Double, String, String, String)] = Seq(
     ("payment-01", "USA", 100.0, "2023-02-15 00:00:00", "2023-02-08 00:00:00", "COMPLETED"),
     ("payment-02", "Japan", 400.0, "2023-03-15 00:00:00", "2023-03-08 00:00:00", "COMPLETED"),
@@ -109,6 +190,10 @@ object TaskData {
     ("payment-04", "USA", 500.0, "2023-05-15 00:00:00", "2023-05-08 00:00:00", "COMPLETED")
   )
 
+  /** Seq with not completed payments generated statically for Test purposes.
+   *
+   * @return Seq with not completed payments.
+   */
   def createSampleNotCompletedPayments: Seq[(String, String, Double, String, String, String)] = Seq(
     ("payment-05", "Japan", 350.0, "2023-07-15 00:00:00", "", "NOT COMPLETED"),
     ("payment-06", "France", 200.0, "2023-07-15 00:00:00", "", "NOT COMPLETED")
@@ -116,6 +201,10 @@ object TaskData {
 
   // CREATE DYNAMICALLY GENERATED DATAFRAMES
 
+  /** DF with users generated dynamically for Test purposes.
+   *
+   * @return DF with users.
+   */
   def createDynamicallyGeneratedSampleUsersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createDynamicallyGeneratedSampleUsers(USERS_COUNT))
       .withColumnRenamed("_1", "UserId")
@@ -127,6 +216,10 @@ object TaskData {
       .withColumnRenamed("_7", "Address")
   }
 
+  /** DF with completed orders generated dynamically for Test purposes.
+   *
+   * @return DF with completed orders.
+   */
   def createDynamicallyGeneratedSampleCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createDynamicallyGeneratedSampleCompletedOrders(COMPLETED_ORDERS_COUNT))
       .withColumnRenamed("_1", "OrderId")
@@ -142,6 +235,10 @@ object TaskData {
       .withColumnRenamed("_11", "Status")
   }
 
+  /** DF with not completed orders generated dynamically for Test purposes.
+   *
+   * @return DF with not completed orders.
+   */
   def createDynamicallyGeneratedSampleNotCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createDynamicallyGeneratedSampleNotCompletedOrders(NOT_COMPLETED_ORDERS_COUNT))
       .withColumnRenamed("_1", "OrderId")
@@ -157,6 +254,10 @@ object TaskData {
       .withColumnRenamed("_11", "Status")
   }
 
+  /** DF with products generated dynamically for Test purposes.
+   *
+   * @return DF with products.
+   */
   def createDynamicallyGeneratedSampleProductsDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createDynamicallyGeneratedSampleProducts(PRODUCTS_COUNT))
       .withColumnRenamed("_1", "ProductId")
@@ -168,6 +269,10 @@ object TaskData {
       .withColumnRenamed("_7", "MarketEntranceDate")
   }
 
+  /** DF with categories generated dynamically for Test purposes.
+   *
+   * @return DF with categories.
+   */
   def createDynamicallyGeneratedSampleCategoriesDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createDynamicallyGeneratedSampleCategories(CATEGORIES_COUNT))
       .withColumnRenamed("_1", "CategoryId")
@@ -178,6 +283,10 @@ object TaskData {
 
   // CREATE STATICALLY GENERATED DATAFRAMES
 
+  /** DF with users generated statically for Test purposes.
+   *
+   * @return DF with users.
+   */
   def createSampleUsersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleUsers)
       .withColumnRenamed("_1", "UserId")
@@ -189,6 +298,10 @@ object TaskData {
       .withColumnRenamed("_7", "Address")
   }
 
+  /** DF with completed orders generated statically for Test purposes.
+   *
+   * @return DF with completed orders.
+   */
   def createSampleCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleCompletedOrders)
       .withColumnRenamed("_1", "OrderId")
@@ -204,6 +317,10 @@ object TaskData {
       .withColumnRenamed("_11", "Status")
   }
 
+  /** DF with not completed orders generated statically for Test purposes.
+   *
+   * @return DF with not completed orders.
+   */
   def createSampleNotCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleNotCompletedOrders)
       .withColumnRenamed("_1", "OrderId")
@@ -219,6 +336,10 @@ object TaskData {
       .withColumnRenamed("_11", "Status")
   }
 
+  /** DF with products generated statically for Test purposes.
+   *
+   * @return DF with products.
+   */
   def createSampleProductsDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleProducts)
       .withColumnRenamed("_1", "ProductId")
@@ -230,6 +351,10 @@ object TaskData {
       .withColumnRenamed("_7", "MarketEntranceDate")
   }
 
+  /** DF with categories generated statically for Test purposes.
+   *
+   * @return DF with categories.
+   */
   def createSampleCategoriesDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleCategories)
       .withColumnRenamed("_1", "CategoryId")
@@ -238,6 +363,10 @@ object TaskData {
       .withColumnRenamed("_4", "Country")
   }
 
+  /** DF with completed payments generated statically for Test purposes.
+   *
+   * @return DF with completed payments.
+   */
   def createSampleCompletedPaymentsDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleCompletedPayments)
       .withColumnRenamed("_1", "PaymentId")
@@ -248,6 +377,10 @@ object TaskData {
       .withColumnRenamed("_6", "PaymentStatus")
   }
 
+  /** DF with not completed payments generated statically for Test purposes.
+   *
+   * @return DF with not completed payments.
+   */
   def createSampleNotCompletedPaymentsDF(implicit spark: SparkSession): DataFrame = {
     spark.createDataFrame(createSampleNotCompletedPayments)
       .withColumnRenamed("_1", "PaymentId")

--- a/src/main/scala/example/TaskDatabase.scala
+++ b/src/main/scala/example/TaskDatabase.scala
@@ -2,6 +2,10 @@ package example
 
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
+/** Represents all the communication with Spark date warehouse tables and Parquet files.
+ *
+ */
+
 object TaskDatabase {
   val DBWAREHOUSE = "spark-warehouse"
   val DATABASE = "db"
@@ -12,38 +16,74 @@ object TaskDatabase {
   val COMPLETED_ORDERS = "completed_orders"
   val NOT_COMPLETED_ORDERS = "not_completed_orders"
 
+  /** DF loaded from local data warehouse.
+   *
+   * @param tableName - table name
+   * @param dbName - database name
+   * @return DF loaded from local data warehouse.
+   */
   def loadDataFrameFromDatabase(tableName: String, dbName: String = DATABASE)(implicit spark: SparkSession): DataFrame = {
     spark
       .read
       .table(dbName + "." + tableName)
   }
 
+  /** DF loaded from local data warehouse (Parquet files).
+   *
+   * @param tableName - table name
+   * @param dbWarehousePath - local data warehouse path
+   * @param dbName - database name
+   * @return DF loaded from local data warehouse (Parquet files).
+   */
   def loadDataFrameFromParquetFiles(tableName: String, dbWarehousePath: String = DBWAREHOUSE, dbName: String = DATABASE)(implicit spark: SparkSession): DataFrame = {
     spark
       .read
       .parquet(dbWarehousePath + "/" + dbName + "." + dbName + "/" + tableName)
   }
 
+  /** DF with users loaded from local data warehouse (Parquet files).
+   *
+   * @return DF with users loaded from local data warehouse (Parquet files).
+   */
   def loadSampleUsersDF(implicit spark: SparkSession): DataFrame = {
     loadDataFrameFromParquetFiles(USERS)
   }
 
+  /** DF with completed orders loaded from local data warehouse (Parquet files).
+   *
+   * @return DF with completed orders loaded from local data warehouse (Parquet files).
+   */
   def loadSampleCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
     loadDataFrameFromParquetFiles(COMPLETED_ORDERS)
   }
 
+  /** DF with not completed orders loaded from local data warehouse (Parquet files).
+   *
+   * @return DF with not completed orders loaded from local data warehouse (Parquet files).
+   */
   def loadSampleNotCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
     loadDataFrameFromParquetFiles(NOT_COMPLETED_ORDERS)
   }
 
+  /** DF with products loaded from local data warehouse (Parquet files).
+   *
+   * @return DF with products loaded from local data warehouse (Parquet files).
+   */
   def loadSampleProductsDF(implicit spark: SparkSession): DataFrame = {
     loadDataFrameFromParquetFiles(PRODUCTS)
   }
 
+  /** DF with categories loaded from local data warehouse (Parquet files).
+   *
+   * @return DF with categories loaded from local data warehouse (Parquet files).
+   */
   def loadSampleCategoriesDF(implicit spark: SparkSession): DataFrame = {
     loadDataFrameFromParquetFiles(CATEGORIES)
   }
 
+  /** All DFs loaded from local data warehouse and printed.
+   *
+   */
   def loadDataFromTheLocalDatabase(implicit spark: SparkSession): Unit = {
     // LOAD TEST DATA
     loadDataFrameFromDatabase(TaskDatabase.USERS).show()
@@ -53,11 +93,18 @@ object TaskDatabase {
     loadDataFrameFromDatabase(TaskDatabase.NOT_COMPLETED_ORDERS).show()
   }
 
+  /** Creation of database if not exists in the local data warehouse.
+   * @param dbName - database name
+   */
   def createLocalDatabase(dbName: String)(implicit spark: SparkSession): Unit = {
     spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName;")
     spark.sql(s"USE $dbName;")
   }
 
+  /** Saving a single DF to the local data warehouse.
+   * @param tableName - table name
+   * @param df - DF to be saved
+   */
   def saveDataFrameToTheLocalDatabase(tableName: String, df: DataFrame): Unit = {
     df
       .write
@@ -65,6 +112,9 @@ object TaskDatabase {
       .saveAsTable(tableName)
   }
 
+  /** Creation of database if not exists in the local data warehouse. Saving all DFs to the local data warehouse.
+   * @param dbName - database name
+   */
   def saveDataToTheLocalDatabase(dbName: String)(implicit spark: SparkSession): Unit = {
     createLocalDatabase(dbName)
     saveDataFrameToTheLocalDatabase(USERS, TaskData.createSampleUsersDF)
@@ -74,6 +124,9 @@ object TaskDatabase {
     saveDataFrameToTheLocalDatabase(NOT_COMPLETED_ORDERS, TaskData.createSampleNotCompletedOrdersDF)
   }
 
+  /** Creation of the Test Spark Session object. Creation of database if not exists in the local data warehouse. Saving all DFs to the local data warehouse.
+   *  Second main method to fill the local data warehouse with data before running unit tests or the other first main function.
+   */
   def main(args: Array[String]): Unit = {
     // CREATE SPARK SESSION
     implicit val spark: SparkSession = TaskInitialization.createLocalSparkSession

--- a/src/main/scala/example/TaskDatabase.scala
+++ b/src/main/scala/example/TaskDatabase.scala
@@ -3,6 +3,7 @@ package example
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
 object TaskDatabase {
+  val DBWAREHOUSE = "spark-warehouse"
   val DATABASE = "db"
 
   val USERS = "users"
@@ -11,9 +12,45 @@ object TaskDatabase {
   val COMPLETED_ORDERS = "completed_orders"
   val NOT_COMPLETED_ORDERS = "not_completed_orders"
 
-  def loadDataFrameFromDatabase(dbName: String, tableName: String)(implicit spark: SparkSession): DataFrame = {
-    spark.read
+  def loadDataFrameFromDatabase(tableName: String, dbName: String = DATABASE)(implicit spark: SparkSession): DataFrame = {
+    spark
+      .read
       .table(dbName + "." + tableName)
+  }
+
+  def loadDataFrameFromParquetFiles(tableName: String, dbWarehousePath: String = DBWAREHOUSE, dbName: String = DATABASE)(implicit spark: SparkSession): DataFrame = {
+    spark
+      .read
+      .parquet(dbWarehousePath + "/" + dbName + "." + dbName + "/" + tableName)
+  }
+
+  def loadSampleUsersDF(implicit spark: SparkSession): DataFrame = {
+    loadDataFrameFromParquetFiles(USERS)
+  }
+
+  def loadSampleCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
+    loadDataFrameFromParquetFiles(COMPLETED_ORDERS)
+  }
+
+  def loadSampleNotCompletedOrdersDF(implicit spark: SparkSession): DataFrame = {
+    loadDataFrameFromParquetFiles(NOT_COMPLETED_ORDERS)
+  }
+
+  def loadSampleProductsDF(implicit spark: SparkSession): DataFrame = {
+    loadDataFrameFromParquetFiles(PRODUCTS)
+  }
+
+  def loadSampleCategoriesDF(implicit spark: SparkSession): DataFrame = {
+    loadDataFrameFromParquetFiles(CATEGORIES)
+  }
+
+  def loadDataFromTheLocalDatabase(implicit spark: SparkSession): Unit = {
+    // LOAD TEST DATA
+    loadDataFrameFromDatabase(TaskDatabase.USERS).show()
+    loadDataFrameFromDatabase(TaskDatabase.PRODUCTS).show()
+    loadDataFrameFromDatabase(TaskDatabase.CATEGORIES).show()
+    loadDataFrameFromDatabase(TaskDatabase.COMPLETED_ORDERS).show()
+    loadDataFrameFromDatabase(TaskDatabase.NOT_COMPLETED_ORDERS).show()
   }
 
   def createLocalDatabase(dbName: String)(implicit spark: SparkSession): Unit = {
@@ -22,7 +59,8 @@ object TaskDatabase {
   }
 
   def saveDataFrameToTheLocalDatabase(tableName: String, df: DataFrame): Unit = {
-    df.write
+    df
+      .write
       .mode(SaveMode.Overwrite)
       .saveAsTable(tableName)
   }
@@ -34,15 +72,6 @@ object TaskDatabase {
     saveDataFrameToTheLocalDatabase(CATEGORIES, TaskData.createSampleCategoriesDF)
     saveDataFrameToTheLocalDatabase(COMPLETED_ORDERS, TaskData.createSampleCompletedOrdersDF)
     saveDataFrameToTheLocalDatabase(NOT_COMPLETED_ORDERS, TaskData.createSampleNotCompletedOrdersDF)
-  }
-
-  def loadDataFromTheLocalDatabase(implicit spark: SparkSession): Unit = {
-    // LOAD TEST DATA
-    loadDataFrameFromDatabase(TaskDatabase.DATABASE, TaskDatabase.USERS).show()
-    loadDataFrameFromDatabase(TaskDatabase.DATABASE, TaskDatabase.PRODUCTS).show()
-    loadDataFrameFromDatabase(TaskDatabase.DATABASE, TaskDatabase.CATEGORIES).show()
-    loadDataFrameFromDatabase(TaskDatabase.DATABASE, TaskDatabase.COMPLETED_ORDERS).show()
-    loadDataFrameFromDatabase(TaskDatabase.DATABASE, TaskDatabase.NOT_COMPLETED_ORDERS).show()
   }
 
   def main(args: Array[String]): Unit = {

--- a/src/main/scala/example/TaskDatabase.scala
+++ b/src/main/scala/example/TaskDatabase.scala
@@ -1,0 +1,54 @@
+package example
+
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+
+object TaskDatabase {
+  val DATABASE = "db"
+
+  val USERS = "users"
+  val PRODUCTS = "products"
+  val CATEGORIES = "categories"
+  val COMPLETED_ORDERS = "completed_orders"
+  val NOT_COMPLETED_ORDERS = "not_completed_orders"
+
+  def loadDataFrameFromDatabase(dbName: String, tableName: String)(implicit spark: SparkSession): DataFrame = {
+    spark.read
+      .table(dbName + "." + tableName)
+  }
+
+  def createLocalDatabase(dbName: String)(implicit spark: SparkSession): Unit = {
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $dbName;")
+    spark.sql(s"USE $dbName;")
+  }
+
+  def saveDataFrameToTheLocalDatabase(tableName: String, df: DataFrame): Unit = {
+    df.write
+      .mode(SaveMode.Overwrite)
+      .saveAsTable(tableName)
+  }
+
+  def saveDataToTheLocalDatabase(dbName: String)(implicit spark: SparkSession): Unit = {
+    createLocalDatabase(dbName)
+    saveDataFrameToTheLocalDatabase(USERS, TaskData.createSampleUsersDF)
+    saveDataFrameToTheLocalDatabase(PRODUCTS, TaskData.createSampleProductsDF)
+    saveDataFrameToTheLocalDatabase(CATEGORIES, TaskData.createSampleCategoriesDF)
+    saveDataFrameToTheLocalDatabase(COMPLETED_ORDERS, TaskData.createSampleCompletedOrdersDF)
+    saveDataFrameToTheLocalDatabase(NOT_COMPLETED_ORDERS, TaskData.createSampleNotCompletedOrdersDF)
+  }
+
+  def loadDataFromTheLocalDatabase(implicit spark: SparkSession): Unit = {
+    // LOAD TEST DATA
+    loadDataFrameFromDatabase(TaskDatabase.DATABASE, TaskDatabase.USERS).show()
+    loadDataFrameFromDatabase(TaskDatabase.DATABASE, TaskDatabase.PRODUCTS).show()
+    loadDataFrameFromDatabase(TaskDatabase.DATABASE, TaskDatabase.CATEGORIES).show()
+    loadDataFrameFromDatabase(TaskDatabase.DATABASE, TaskDatabase.COMPLETED_ORDERS).show()
+    loadDataFrameFromDatabase(TaskDatabase.DATABASE, TaskDatabase.NOT_COMPLETED_ORDERS).show()
+  }
+
+  def main(args: Array[String]): Unit = {
+    // CREATE SPARK SESSION
+    implicit val spark: SparkSession = TaskInitialization.createLocalSparkSession
+    // SAVE TEST DATA
+    saveDataToTheLocalDatabase(DATABASE)
+  }
+}

--- a/src/main/scala/example/TaskInitialization.scala
+++ b/src/main/scala/example/TaskInitialization.scala
@@ -6,21 +6,21 @@ object TaskInitialization {
   // CREATE SPARK SESSION
 
   def createSparkSession: SparkSession = {
-    val ss = SparkSession.builder
+    SparkSession.builder
       .appName("Spark Scala Task")
-      .master("local[*]")
+   // .master("local[*]")
+      .config("spark.sql.session.timeZone", "UTC")
+   // .config("spark.sql.autoBroadcastJoinThreshold", -1)
       .getOrCreate()
- // ss.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
-    ss.conf.set("spark.sql.session.timeZone", "UTC")
-    ss
   }
 
   def createLocalSparkSession: SparkSession = {
-    val ss = SparkSession.builder
+    SparkSession.builder
       .appName("Spark Scala Task")
       .master("local[*]")
+   // .config("spark.sql.warehouse.dir", "spark-warehouse")
+   // .config("spark.sql.legacy.allowCreatingManagedTableUsingNonemptyLocation", "true")
+      .config("spark.sql.session.timeZone", "UTC")
       .getOrCreate()
-    ss.conf.set("spark.sql.session.timeZone", "UTC")
-    ss
   }
 }

--- a/src/main/scala/example/TaskInitialization.scala
+++ b/src/main/scala/example/TaskInitialization.scala
@@ -5,16 +5,21 @@ import org.apache.spark.sql.SparkSession
 object TaskInitialization {
   // CREATE SPARK SESSION
 
-  def createSparkSession: SparkSession = SparkSession.builder
-    .appName("Spark Scala Task")
-    .getOrCreate()
+  def createSparkSession: SparkSession = {
+    val ss = SparkSession.builder
+      .appName("Spark Scala Task")
+      .master("local[*]")
+      .getOrCreate()
+ // ss.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
+    ss.conf.set("spark.sql.session.timeZone", "UTC")
+    ss
+  }
 
   def createLocalSparkSession: SparkSession = {
     val ss = SparkSession.builder
       .appName("Spark Scala Task")
       .master("local[*]")
       .getOrCreate()
-    ss.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
     ss.conf.set("spark.sql.session.timeZone", "UTC")
     ss
   }

--- a/src/main/scala/example/TaskInitialization.scala
+++ b/src/main/scala/example/TaskInitialization.scala
@@ -2,9 +2,17 @@ package example
 
 import org.apache.spark.sql.SparkSession
 
+/** Represents creation of Spark contexts.
+ *
+ */
+
 object TaskInitialization {
   // CREATE SPARK SESSION
 
+  /** Spark session for Production code.
+   *
+   * @return Spark session object.
+   */
   def createSparkSession: SparkSession = {
     SparkSession.builder
       .appName("Spark Scala Task")
@@ -14,6 +22,10 @@ object TaskInitialization {
       .getOrCreate()
   }
 
+  /** Spark session for Test code.
+   *
+   * @return Spark session object.
+   */
   def createLocalSparkSession: SparkSession = {
     SparkSession.builder
       .appName("Spark Scala Task")

--- a/src/main/scala/example/TaskMain.scala
+++ b/src/main/scala/example/TaskMain.scala
@@ -18,13 +18,13 @@ object TaskMain {
 
     // STATIC
 
-    val usersDF = TaskData.createSampleUsersDF(spark)
-    val productsDF = TaskData.createSampleProductsDF(spark)
-    val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedPaymentsDF = TaskData.createSampleCompletedPaymentsDF(spark)
-    val notCompletedPaymentsDF = TaskData.createSampleNotCompletedPaymentsDF(spark)
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
+    //  val usersDF = TaskData.createSampleUsersDF(spark)
+    //  val productsDF = TaskData.createSampleProductsDF(spark)
+    //  val categoriesDF = TaskData.createSampleCategoriesDF(spark)
+    //  val completedPaymentsDF = TaskData.createSampleCompletedPaymentsDF(spark)
+    //  val notCompletedPaymentsDF = TaskData.createSampleNotCompletedPaymentsDF(spark)
+    //  val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
+    //  val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
 
     // DYNAMIC
 
@@ -134,7 +134,7 @@ object TaskMain {
 
     // transformationTask2WithSimpleApproachWithComplicationsDF.show()
 
-    // spark.stop()
+    spark.stop()
   }
 }
 

--- a/src/main/scala/example/TaskMain.scala
+++ b/src/main/scala/example/TaskMain.scala
@@ -12,27 +12,27 @@ object TaskMain {
   def main(args: Array[String]): Unit = {
     // CREATE SPARK SESSION
 
-    val spark = TaskInitialization.createLocalSparkSession
+    implicit val spark: SparkSession = TaskInitialization.createSparkSession
 
     // CREATE TEST DATAFRAMES
 
     // STATIC
 
-    //  val usersDF = TaskData.createSampleUsersDF(spark)
-    //  val productsDF = TaskData.createSampleProductsDF(spark)
-    //  val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    //  val completedPaymentsDF = TaskData.createSampleCompletedPaymentsDF(spark)
-    //  val notCompletedPaymentsDF = TaskData.createSampleNotCompletedPaymentsDF(spark)
-    //  val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
-    //  val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
+    val usersDF = TaskData.createSampleUsersDF
+    val productsDF = TaskData.createSampleProductsDF
+    val categoriesDF = TaskData.createSampleCategoriesDF
+    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
 
     // DYNAMIC
 
-    //  val usersDF = TaskData.createDynamicallyGeneratedSampleUsersDF(spark)
-    //  val productsDF = TaskData.createDynamicallyGeneratedSampleProductsDF(spark)
-    //  val categoriesDF = TaskData.createDynamicallyGeneratedSampleCategoriesDF(spark)
-    //  val completedOrdersDF = TaskData.createDynamicallyGeneratedSampleCompletedOrdersDF(spark)
-    //  val notCompletedOrdersDF = TaskData.createDynamicallyGeneratedSampleNotCompletedOrdersDF(spark)
+    //  val usersDF = TaskData.createDynamicallyGeneratedSampleUsersDF
+    //  val productsDF = TaskData.createDynamicallyGeneratedSampleProductsDF
+    //  val categoriesDF = TaskData.createDynamicallyGeneratedSampleCategoriesDF
+    //  val completedOrdersDF = TaskData.createDynamicallyGeneratedSampleCompletedOrdersDF
+    //  val notCompletedOrdersDF = TaskData.createDynamicallyGeneratedSampleNotCompletedOrdersDF
+
+    // SCHEMAS
 
     // usersDF.printSchema()
     // productsDF.printSchema()
@@ -42,97 +42,83 @@ object TaskMain {
     // completedOrdersDF.printSchema()
     // notCompletedOrdersDF.printSchema()
 
-    //  val transformationTask1WithSimpleApproachDF = transformationTask1WithSimpleApproach(
-    //    spark,
-    //    notCompletedOrdersDF,
-    //    completedOrdersDF,
-    //    notCompletedPaymentsDF,
-    //    completedPaymentsDF,
-    //    usersDF,
-    //    productsDF,
-    //    categoriesDF
-    //  )
+    // TASK 1
 
-    // transformationTask1WithSimpleApproachDF.show()
+    // Simple approach.
+
+    val transformationTask1WithSimpleApproachDF = transformationTask1WithSimpleApproach(
+      notCompletedOrdersDF,
+      completedOrdersDF,
+      usersDF,
+      productsDF,
+      categoriesDF
+    )
+
+    transformationTask1WithSimpleApproachDF.show()
 
     // Approach with repartitioning.
 
-    //  val transformationTask1WithRepartitioningApproachDF = transformationTask1WithRepartitioningApproach(
-    //    spark,
-    //    notCompletedOrdersDF,
-    //    completedOrdersDF,
-    //    notCompletedPaymentsDF,
-    //    completedPaymentsDF,
-    //    usersDF,
-    //    productsDF,
-    //    categoriesDF
-    //  )
+    val transformationTask1WithRepartitioningApproachDF = transformationTask1WithRepartitioningApproach(
+      notCompletedOrdersDF,
+      completedOrdersDF,
+      usersDF,
+      productsDF,
+      categoriesDF
+    )
 
-    // transformationTask1WithRepartitioningApproachDF.show()
+    transformationTask1WithRepartitioningApproachDF.show()
 
-    // Simple approach with "complications"
+    // Simple approach with "complications".
 
-    //  val transformationTask1WithSimpleApproachWithComplicationsDF = transformationTask1WithSimpleApproachWithComplications(
-    //    spark,
-    //    notCompletedOrdersDF,
-    //    completedOrdersDF,
-    //    null,
-    //    null,
-    //    usersDF,
-    //    productsDF,
-    //    categoriesDF,
-    //   "2023-03-01"
-    //  )
-    //
-    //  transformationTask1WithSimpleApproachWithComplicationsDF.show()
+    val transformationTask1WithSimpleApproachWithComplicationsDF = transformationTask1WithSimpleApproachWithComplications(
+      notCompletedOrdersDF,
+      completedOrdersDF,
+      usersDF,
+      productsDF,
+      categoriesDF,
+     "2023-03-01"
+    )
+
+    transformationTask1WithSimpleApproachWithComplicationsDF.show()
 
     // TASK 2
 
-    // Simple approach
+    // Simple approach.
 
-    //  val transformationTask2WithSimpleApproachDF = transformationTask2WithSimpleApproach(
-    //    spark,
-    //    notCompletedOrdersDF,
-    //    completedOrdersDF,
-    //    null,
-    //    null,
-    //    usersDF,
-    //    productsDF,
-    //    categoriesDF
-    //  )
-    //
-    //  transformationTask2WithSimpleApproachDF.show()
+    val transformationTask2WithSimpleApproachDF = transformationTask2WithSimpleApproach(
+      notCompletedOrdersDF,
+      completedOrdersDF,
+      usersDF,
+      productsDF,
+      categoriesDF
+    )
+
+    transformationTask2WithSimpleApproachDF.show()
 
     // Approach with repartitioning.
 
-    //  val transformationTask2WithRepartitioningApproachDF = transformationTask2WithRepartitioningApproach(
-    //    spark,
-    //    notCompletedOrdersDF,
-    //    completedOrdersDF,
-    //    null,
-    //    null,
-    //    usersDF,
-    //    productsDF,
-    //    categoriesDF
-    //  )
-    //
-    //  transformationTask2WithRepartitioningApproachDF.show()
+    val transformationTask2WithRepartitioningApproachDF = transformationTask2WithRepartitioningApproach(
+      notCompletedOrdersDF,
+      completedOrdersDF,
+      usersDF,
+      productsDF,
+      categoriesDF
+    )
 
-    // Simple approach with "complications"
+    transformationTask2WithRepartitioningApproachDF.show()
 
-    //  val transformationTask2WithSimpleApproachWithComplicationsDF = transformationTask2WithSimpleApproachWithComplications(
-    //    spark,
-    //    notCompletedOrdersDF,
-    //    completedOrdersDF,
-    //    null,
-    //    null,
-    //    usersDF,
-    //    productsDF,
-    //    categoriesDF,
-    //    "2023-03-01"
-    //  )
+    // Simple approach with "complications".
 
-    // transformationTask2WithSimpleApproachWithComplicationsDF.show()
+    val transformationTask2WithSimpleApproachWithComplicationsDF = transformationTask2WithSimpleApproachWithComplications(
+      notCompletedOrdersDF,
+      completedOrdersDF,
+      usersDF,
+      productsDF,
+      categoriesDF,
+      "2023-03-01"
+    )
+
+    transformationTask2WithSimpleApproachWithComplicationsDF.show()
 
     spark.stop()
   }

--- a/src/main/scala/example/TaskMain.scala
+++ b/src/main/scala/example/TaskMain.scala
@@ -16,21 +16,13 @@ object TaskMain {
 
     // CREATE TEST DATAFRAMES
 
-    // STATIC
+    // LOAD TABLES / PARQUET FILES
 
-    val usersDF = TaskData.createSampleUsersDF
-    val productsDF = TaskData.createSampleProductsDF
-    val categoriesDF = TaskData.createSampleCategoriesDF
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
-
-    // DYNAMIC
-
-    //  val usersDF = TaskData.createDynamicallyGeneratedSampleUsersDF
-    //  val productsDF = TaskData.createDynamicallyGeneratedSampleProductsDF
-    //  val categoriesDF = TaskData.createDynamicallyGeneratedSampleCategoriesDF
-    //  val completedOrdersDF = TaskData.createDynamicallyGeneratedSampleCompletedOrdersDF
-    //  val notCompletedOrdersDF = TaskData.createDynamicallyGeneratedSampleNotCompletedOrdersDF
+    val usersDF = TaskDatabase.loadSampleUsersDF
+    val productsDF = TaskDatabase.loadSampleProductsDF
+    val categoriesDF = TaskDatabase.loadSampleCategoriesDF
+    val completedOrdersDF = TaskDatabase.loadSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskDatabase.loadSampleNotCompletedOrdersDF
 
     // SCHEMAS
 

--- a/src/main/scala/example/TaskMain.scala
+++ b/src/main/scala/example/TaskMain.scala
@@ -8,6 +8,10 @@ import example.Task2SimpleApproach.transformationTask2WithSimpleApproach
 import example.Task2SimpleApproachWithComplications.transformationTask2WithSimpleApproachWithComplications
 import org.apache.spark.sql.SparkSession
 
+/** Represents main class - for experimenting and Production flow.
+ *
+ */
+
 object TaskMain {
   def main(args: Array[String]): Unit = {
     // CREATE SPARK SESSION

--- a/src/main/scala/example/TaskSchema.scala
+++ b/src/main/scala/example/TaskSchema.scala
@@ -2,6 +2,10 @@ package example
 
 import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, StructType}
 
+/** Represents all the schemas - for documentation purposes.
+ *
+ */
+
 object TaskSchema {
   // CREATE SCHEMAS (FOR DOCUMENTATION PURPOSES ONLY)
 

--- a/src/test/scala/Task1RepartitioningApproachTest.scala
+++ b/src/test/scala/Task1RepartitioningApproachTest.scala
@@ -39,27 +39,10 @@ class Task1RepartitioningApproachTest extends AnyFlatSpec {
     //  |         user-03|    ultra-laptops-01|   200.0|
     //  +----------------+--------------------+--------+
 
-    val results = transformationTask1WithRepartitioningApproachDF.collectAsList()
+    val obtainedResults = transformationTask1WithRepartitioningApproachDF
+    val expectedResults = TestUtils.getBasicQueryExpectedResult(spark)
 
-    assert(results.size() == 5)
-
-    assert(results.get(0).getString(0) == "user-01")
-    assert(results.get(1).getString(0) == "user-02")
-    assert(results.get(2).getString(0) == "user-02")
-    assert(results.get(3).getString(0) == "user-03")
-    assert(results.get(4).getString(0) == "user-03")
-
-    assert(results.get(0).getString(1) == "office-laptops-01")
-    assert(results.get(1).getString(1) == "regular-laptops-01")
-    assert(results.get(2).getString(1) == "premium-laptops-01")
-    assert(results.get(3).getString(1) == "super-laptops-01")
-    assert(results.get(4).getString(1) == "ultra-laptops-01")
-
-    assert(results.get(0).getDouble(2) == 600.0)
-    assert(results.get(1).getDouble(2) == 400.0)
-    assert(results.get(2).getDouble(2) == 350.0)
-    assert(results.get(3).getDouble(2) == 300.0)
-    assert(results.get(4).getDouble(2) == 200.0)
+    assert(TestUtils.areDataFrameEquals(obtainedResults, expectedResults))
 
     // CLEANUP
 

--- a/src/test/scala/Task1RepartitioningApproachTest.scala
+++ b/src/test/scala/Task1RepartitioningApproachTest.scala
@@ -13,8 +13,6 @@ class Task1RepartitioningApproachTest extends AnyFlatSpec {
     val usersDF = TaskData.createSampleUsersDF(spark)
     val productsDF = TaskData.createSampleProductsDF(spark)
     val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedPaymentsDF = TaskData.createSampleCompletedPaymentsDF(spark)
-    val notCompletedPaymentsDF = TaskData.createSampleNotCompletedPaymentsDF(spark)
     val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
     val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
 

--- a/src/test/scala/Task1RepartitioningApproachTest.scala
+++ b/src/test/scala/Task1RepartitioningApproachTest.scala
@@ -1,5 +1,5 @@
 import example.Task1RepartitioningApproach.transformationTask1WithRepartitioningApproach
-import example.{TaskData, TaskInitialization}
+import example.{TaskDatabase, TaskInitialization}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -11,11 +11,11 @@ class Task1RepartitioningApproachTest extends AnyFlatSpec {
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF
-    val productsDF = TaskData.createSampleProductsDF
-    val categoriesDF = TaskData.createSampleCategoriesDF
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
+    val usersDF = TaskDatabase.loadSampleUsersDF
+    val productsDF = TaskDatabase.loadSampleProductsDF
+    val categoriesDF = TaskDatabase.loadSampleCategoriesDF
+    val completedOrdersDF = TaskDatabase.loadSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskDatabase.loadSampleNotCompletedOrdersDF
 
     // RUN
 

--- a/src/test/scala/Task1RepartitioningApproachTest.scala
+++ b/src/test/scala/Task1RepartitioningApproachTest.scala
@@ -1,25 +1,25 @@
 import example.Task1RepartitioningApproach.transformationTask1WithRepartitioningApproach
 import example.{TaskData, TaskInitialization}
+import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
 class Task1RepartitioningApproachTest extends AnyFlatSpec {
   "Task1RepartitioningApproach" should "returns correct DataFrame" in {
     // CREATE SPARK SESSION
 
-    val spark = TaskInitialization.createLocalSparkSession
+    implicit val spark: SparkSession = TaskInitialization.createLocalSparkSession
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF(spark)
-    val productsDF = TaskData.createSampleProductsDF(spark)
-    val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
+    val usersDF = TaskData.createSampleUsersDF
+    val productsDF = TaskData.createSampleProductsDF
+    val categoriesDF = TaskData.createSampleCategoriesDF
+    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
 
     // RUN
 
     val transformationTask1WithRepartitioningApproachDF = transformationTask1WithRepartitioningApproach(
-      spark,
       notCompletedOrdersDF,
       completedOrdersDF,
       usersDF,

--- a/src/test/scala/Task1RepartitioningApproachTest.scala
+++ b/src/test/scala/Task1RepartitioningApproachTest.scala
@@ -24,8 +24,6 @@ class Task1RepartitioningApproachTest extends AnyFlatSpec {
       spark,
       notCompletedOrdersDF,
       completedOrdersDF,
-      notCompletedPaymentsDF,
-      completedPaymentsDF,
       usersDF,
       productsDF,
       categoriesDF
@@ -67,6 +65,6 @@ class Task1RepartitioningApproachTest extends AnyFlatSpec {
 
     // CLEANUP
 
-    // spark.stop()
+    spark.stop()
   }
 }

--- a/src/test/scala/Task1SimpleApproachTest.scala
+++ b/src/test/scala/Task1SimpleApproachTest.scala
@@ -13,8 +13,6 @@ class Task1SimpleApproachTest extends AnyFlatSpec {
     val usersDF = TaskData.createSampleUsersDF(spark)
     val productsDF = TaskData.createSampleProductsDF(spark)
     val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedPaymentsDF = TaskData.createSampleCompletedPaymentsDF(spark)
-    val notCompletedPaymentsDF = TaskData.createSampleNotCompletedPaymentsDF(spark)
     val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
     val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
 

--- a/src/test/scala/Task1SimpleApproachTest.scala
+++ b/src/test/scala/Task1SimpleApproachTest.scala
@@ -24,8 +24,6 @@ class Task1SimpleApproachTest extends AnyFlatSpec {
       spark,
       notCompletedOrdersDF,
       completedOrdersDF,
-      notCompletedPaymentsDF,
-      completedPaymentsDF,
       usersDF,
       productsDF,
       categoriesDF
@@ -67,6 +65,6 @@ class Task1SimpleApproachTest extends AnyFlatSpec {
 
     // CLEANUP
 
-    // spark.stop()
+    spark.stop()
   }
 }

--- a/src/test/scala/Task1SimpleApproachTest.scala
+++ b/src/test/scala/Task1SimpleApproachTest.scala
@@ -39,27 +39,10 @@ class Task1SimpleApproachTest extends AnyFlatSpec {
     //  |         user-03|    ultra-laptops-01|   200.0|
     //  +----------------+--------------------+--------+
 
-    val results = transformationTask1WithSimpleApproachDF.collectAsList()
+    val obtainedResults = transformationTask1WithSimpleApproachDF
+    val expectedResults = TestUtils.getBasicQueryExpectedResult(spark)
 
-    assert(results.size() == 5)
-
-    assert(results.get(0).getString(0) == "user-01")
-    assert(results.get(1).getString(0) == "user-02")
-    assert(results.get(2).getString(0) == "user-02")
-    assert(results.get(3).getString(0) == "user-03")
-    assert(results.get(4).getString(0) == "user-03")
-
-    assert(results.get(0).getString(1) == "office-laptops-01")
-    assert(results.get(1).getString(1) == "regular-laptops-01")
-    assert(results.get(2).getString(1) == "premium-laptops-01")
-    assert(results.get(3).getString(1) == "super-laptops-01")
-    assert(results.get(4).getString(1) == "ultra-laptops-01")
-
-    assert(results.get(0).getDouble(2) == 600.0)
-    assert(results.get(1).getDouble(2) == 400.0)
-    assert(results.get(2).getDouble(2) == 350.0)
-    assert(results.get(3).getDouble(2) == 300.0)
-    assert(results.get(4).getDouble(2) == 200.0)
+    assert(TestUtils.areDataFrameEquals(obtainedResults, expectedResults))
 
     // CLEANUP
 

--- a/src/test/scala/Task1SimpleApproachTest.scala
+++ b/src/test/scala/Task1SimpleApproachTest.scala
@@ -1,25 +1,25 @@
 import example.Task1SimpleApproach.transformationTask1WithSimpleApproach
 import example.{TaskData, TaskInitialization}
+import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
 class Task1SimpleApproachTest extends AnyFlatSpec {
   "Task1SimpleApproach" should "returns correct DataFrame" in {
     // CREATE SPARK SESSION
 
-    val spark = TaskInitialization.createLocalSparkSession
+    implicit val spark: SparkSession = TaskInitialization.createLocalSparkSession
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF(spark)
-    val productsDF = TaskData.createSampleProductsDF(spark)
-    val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
+    val usersDF = TaskData.createSampleUsersDF
+    val productsDF = TaskData.createSampleProductsDF
+    val categoriesDF = TaskData.createSampleCategoriesDF
+    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
 
     // RUN
 
     val transformationTask1WithSimpleApproachDF = transformationTask1WithSimpleApproach(
-      spark,
       notCompletedOrdersDF,
       completedOrdersDF,
       usersDF,

--- a/src/test/scala/Task1SimpleApproachTest.scala
+++ b/src/test/scala/Task1SimpleApproachTest.scala
@@ -1,5 +1,5 @@
 import example.Task1SimpleApproach.transformationTask1WithSimpleApproach
-import example.{TaskData, TaskInitialization}
+import example.{TaskDatabase, TaskInitialization}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -11,11 +11,11 @@ class Task1SimpleApproachTest extends AnyFlatSpec {
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF
-    val productsDF = TaskData.createSampleProductsDF
-    val categoriesDF = TaskData.createSampleCategoriesDF
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
+    val usersDF = TaskDatabase.loadSampleUsersDF
+    val productsDF = TaskDatabase.loadSampleProductsDF
+    val categoriesDF = TaskDatabase.loadSampleCategoriesDF
+    val completedOrdersDF = TaskDatabase.loadSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskDatabase.loadSampleNotCompletedOrdersDF
 
     // RUN
 

--- a/src/test/scala/Task1SimpleApproachWithComplicationsTest.scala
+++ b/src/test/scala/Task1SimpleApproachWithComplicationsTest.scala
@@ -1,5 +1,5 @@
 import example.Task1SimpleApproachWithComplications.transformationTask1WithSimpleApproachWithComplications
-import example.{TaskData, TaskInitialization}
+import example.{TaskDatabase, TaskInitialization}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -11,11 +11,11 @@ class Task1SimpleApproachWithComplicationsTest extends AnyFlatSpec {
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF
-    val productsDF = TaskData.createSampleProductsDF
-    val categoriesDF = TaskData.createSampleCategoriesDF
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
+    val usersDF = TaskDatabase.loadSampleUsersDF
+    val productsDF = TaskDatabase.loadSampleProductsDF
+    val categoriesDF = TaskDatabase.loadSampleCategoriesDF
+    val completedOrdersDF = TaskDatabase.loadSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskDatabase.loadSampleNotCompletedOrdersDF
 
     // RUN
 

--- a/src/test/scala/Task1SimpleApproachWithComplicationsTest.scala
+++ b/src/test/scala/Task1SimpleApproachWithComplicationsTest.scala
@@ -13,8 +13,6 @@ class Task1SimpleApproachWithComplicationsTest extends AnyFlatSpec {
     val usersDF = TaskData.createSampleUsersDF(spark)
     val productsDF = TaskData.createSampleProductsDF(spark)
     val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedPaymentsDF = TaskData.createSampleCompletedPaymentsDF(spark)
-    val notCompletedPaymentsDF = TaskData.createSampleNotCompletedPaymentsDF(spark)
     val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
     val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
 

--- a/src/test/scala/Task1SimpleApproachWithComplicationsTest.scala
+++ b/src/test/scala/Task1SimpleApproachWithComplicationsTest.scala
@@ -1,25 +1,25 @@
 import example.Task1SimpleApproachWithComplications.transformationTask1WithSimpleApproachWithComplications
 import example.{TaskData, TaskInitialization}
+import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
 class Task1SimpleApproachWithComplicationsTest extends AnyFlatSpec {
   "Task1SimpleApproachWithComplications" should "returns correct DataFrame" in {
     // CREATE SPARK SESSION
 
-    val spark = TaskInitialization.createLocalSparkSession
+    implicit val spark: SparkSession = TaskInitialization.createLocalSparkSession
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF(spark)
-    val productsDF = TaskData.createSampleProductsDF(spark)
-    val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
+    val usersDF = TaskData.createSampleUsersDF
+    val productsDF = TaskData.createSampleProductsDF
+    val categoriesDF = TaskData.createSampleCategoriesDF
+    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
 
     // RUN
 
     val transformationTask1WithSimpleApproachWithComplicationsDF = transformationTask1WithSimpleApproachWithComplications(
-      spark,
       notCompletedOrdersDF,
       completedOrdersDF,
       usersDF,

--- a/src/test/scala/Task1SimpleApproachWithComplicationsTest.scala
+++ b/src/test/scala/Task1SimpleApproachWithComplicationsTest.scala
@@ -39,29 +39,10 @@ class Task1SimpleApproachWithComplicationsTest extends AnyFlatSpec {
     //  |         user-03|              STEPHANE MOREAU|    ultra-laptops-01|   200.0|
     //  +----------------+-----------------------------+--------------------+--------+
 
-    val results = transformationTask1WithSimpleApproachWithComplicationsDF.collectAsList()
+    val obtainedResults = transformationTask1WithSimpleApproachWithComplicationsDF
+    val expectedResults = TestUtils.getComplicatedQueryExpectedResult(spark)
 
-    assert(results.size() == 4)
-
-    assert(results.get(0).getString(0) == "user-01")
-    assert(results.get(1).getString(0) == "user-02")
-    assert(results.get(2).getString(0) == "user-03")
-    assert(results.get(3).getString(0) == "user-03")
-
-    assert(results.get(0).getString(1) == "ANNE ANDERSON")
-    assert(results.get(1).getString(1) == "TOMMY HARADA")
-    assert(results.get(2).getString(1) == "STEPHANE MOREAU")
-    assert(results.get(3).getString(1) == "STEPHANE MOREAU")
-
-    assert(results.get(0).getString(2) == "office-laptops-01")
-    assert(results.get(1).getString(2) == "premium-laptops-01")
-    assert(results.get(2).getString(2) == "super-laptops-01")
-    assert(results.get(3).getString(2) == "ultra-laptops-01")
-
-    assert(results.get(0).getDouble(3) == 500.0)
-    assert(results.get(1).getDouble(3) == 350.0)
-    assert(results.get(2).getDouble(3) == 300.0)
-    assert(results.get(3).getDouble(3) == 200.0)
+    assert(TestUtils.areDataFrameEquals(obtainedResults, expectedResults))
 
     // CLEANUP
 

--- a/src/test/scala/Task1SimpleApproachWithComplicationsTest.scala
+++ b/src/test/scala/Task1SimpleApproachWithComplicationsTest.scala
@@ -1,4 +1,3 @@
-import example.Task1SimpleApproach.transformationTask1WithSimpleApproach
 import example.Task1SimpleApproachWithComplications.transformationTask1WithSimpleApproachWithComplications
 import example.{TaskData, TaskInitialization}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -25,8 +24,6 @@ class Task1SimpleApproachWithComplicationsTest extends AnyFlatSpec {
       spark,
       notCompletedOrdersDF,
       completedOrdersDF,
-      notCompletedPaymentsDF,
-      completedPaymentsDF,
       usersDF,
       productsDF,
       categoriesDF,
@@ -70,6 +67,6 @@ class Task1SimpleApproachWithComplicationsTest extends AnyFlatSpec {
 
     // CLEANUP
 
-    // spark.stop()
+    spark.stop()
   }
 }

--- a/src/test/scala/Task2RepartitioningApproachTest.scala
+++ b/src/test/scala/Task2RepartitioningApproachTest.scala
@@ -1,20 +1,21 @@
 import example.Task2RepartitioningApproach.transformationTask2WithRepartitioningApproach
 import example.{TaskData, TaskInitialization}
+import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
 class Task2RepartitioningApproachTest extends AnyFlatSpec {
   "Task2RepartitioningApproach" should "returns correct DataFrame" in {
     // CREATE SPARK SESSION
 
-    val spark = TaskInitialization.createLocalSparkSession
+    implicit val spark: SparkSession = TaskInitialization.createLocalSparkSession
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF(spark)
-    val productsDF = TaskData.createSampleProductsDF(spark)
-    val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
+    val usersDF = TaskData.createSampleUsersDF
+    val productsDF = TaskData.createSampleProductsDF
+    val categoriesDF = TaskData.createSampleCategoriesDF
+    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
 
     // RUN
 

--- a/src/test/scala/Task2RepartitioningApproachTest.scala
+++ b/src/test/scala/Task2RepartitioningApproachTest.scala
@@ -21,11 +21,8 @@ class Task2RepartitioningApproachTest extends AnyFlatSpec {
     // RUN
 
     val transformationTask2WithRepartitioningApproachDF = transformationTask2WithRepartitioningApproach(
-      spark,
       notCompletedOrdersDF,
       completedOrdersDF,
-      notCompletedPaymentsDF,
-      completedPaymentsDF,
       usersDF,
       productsDF,
       categoriesDF
@@ -67,6 +64,6 @@ class Task2RepartitioningApproachTest extends AnyFlatSpec {
 
     // CLEANUP
 
-    // spark.stop()
+    spark.stop()
   }
 }

--- a/src/test/scala/Task2RepartitioningApproachTest.scala
+++ b/src/test/scala/Task2RepartitioningApproachTest.scala
@@ -13,8 +13,6 @@ class Task2RepartitioningApproachTest extends AnyFlatSpec {
     val usersDF = TaskData.createSampleUsersDF(spark)
     val productsDF = TaskData.createSampleProductsDF(spark)
     val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedPaymentsDF = TaskData.createSampleCompletedPaymentsDF(spark)
-    val notCompletedPaymentsDF = TaskData.createSampleNotCompletedPaymentsDF(spark)
     val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
     val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
 

--- a/src/test/scala/Task2RepartitioningApproachTest.scala
+++ b/src/test/scala/Task2RepartitioningApproachTest.scala
@@ -1,5 +1,5 @@
 import example.Task2RepartitioningApproach.transformationTask2WithRepartitioningApproach
-import example.{TaskData, TaskInitialization}
+import example.{TaskDatabase, TaskInitialization}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -11,11 +11,11 @@ class Task2RepartitioningApproachTest extends AnyFlatSpec {
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF
-    val productsDF = TaskData.createSampleProductsDF
-    val categoriesDF = TaskData.createSampleCategoriesDF
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
+    val usersDF = TaskDatabase.loadSampleUsersDF
+    val productsDF = TaskDatabase.loadSampleProductsDF
+    val categoriesDF = TaskDatabase.loadSampleCategoriesDF
+    val completedOrdersDF = TaskDatabase.loadSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskDatabase.loadSampleNotCompletedOrdersDF
 
     // RUN
 

--- a/src/test/scala/Task2RepartitioningApproachTest.scala
+++ b/src/test/scala/Task2RepartitioningApproachTest.scala
@@ -38,27 +38,10 @@ class Task2RepartitioningApproachTest extends AnyFlatSpec {
     //  |         user-03|    ultra-laptops-01|   200.0|
     //  +----------------+--------------------+--------+
 
-    val results = transformationTask2WithRepartitioningApproachDF.collectAsList()
+    val obtainedResults = transformationTask2WithRepartitioningApproachDF
+    val expectedResults = TestUtils.getBasicQueryExpectedResult(spark)
 
-    assert(results.size() == 5)
-
-    assert(results.get(0).getString(0) == "user-01")
-    assert(results.get(1).getString(0) == "user-02")
-    assert(results.get(2).getString(0) == "user-02")
-    assert(results.get(3).getString(0) == "user-03")
-    assert(results.get(4).getString(0) == "user-03")
-
-    assert(results.get(0).getString(1) == "office-laptops-01")
-    assert(results.get(1).getString(1) == "regular-laptops-01")
-    assert(results.get(2).getString(1) == "premium-laptops-01")
-    assert(results.get(3).getString(1) == "super-laptops-01")
-    assert(results.get(4).getString(1) == "ultra-laptops-01")
-
-    assert(results.get(0).getDouble(2) == 600.0)
-    assert(results.get(1).getDouble(2) == 400.0)
-    assert(results.get(2).getDouble(2) == 350.0)
-    assert(results.get(3).getDouble(2) == 300.0)
-    assert(results.get(4).getDouble(2) == 200.0)
+    assert(TestUtils.areDataFrameEquals(obtainedResults, expectedResults))
 
     // CLEANUP
 

--- a/src/test/scala/Task2SimpleApproachTest.scala
+++ b/src/test/scala/Task2SimpleApproachTest.scala
@@ -38,27 +38,10 @@ class Task2SimpleApproachTest extends AnyFlatSpec {
     //  |         user-03|    ultra-laptops-01|   200.0|
     //  +----------------+--------------------+--------+
 
-    val results = transformationTask2WithSimpleApproachDF.collectAsList()
+    val obtainedResults = transformationTask2WithSimpleApproachDF
+    val expectedResults = TestUtils.getBasicQueryExpectedResult(spark)
 
-    assert(results.size() == 5)
-
-    assert(results.get(0).getString(0) == "user-01")
-    assert(results.get(1).getString(0) == "user-02")
-    assert(results.get(2).getString(0) == "user-02")
-    assert(results.get(3).getString(0) == "user-03")
-    assert(results.get(4).getString(0) == "user-03")
-
-    assert(results.get(0).getString(1) == "office-laptops-01")
-    assert(results.get(1).getString(1) == "regular-laptops-01")
-    assert(results.get(2).getString(1) == "premium-laptops-01")
-    assert(results.get(3).getString(1) == "super-laptops-01")
-    assert(results.get(4).getString(1) == "ultra-laptops-01")
-
-    assert(results.get(0).getDouble(2) == 600.0)
-    assert(results.get(1).getDouble(2) == 400.0)
-    assert(results.get(2).getDouble(2) == 350.0)
-    assert(results.get(3).getDouble(2) == 300.0)
-    assert(results.get(4).getDouble(2) == 200.0)
+    assert(TestUtils.areDataFrameEquals(obtainedResults, expectedResults))
 
     // CLEANUP
 

--- a/src/test/scala/Task2SimpleApproachTest.scala
+++ b/src/test/scala/Task2SimpleApproachTest.scala
@@ -1,20 +1,21 @@
 import example.Task2SimpleApproach.transformationTask2WithSimpleApproach
 import example.{TaskData, TaskInitialization}
+import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
 class Task2SimpleApproachTest extends AnyFlatSpec {
   "Task2SimpleApproach" should "returns correct DataFrame" in {
     // CREATE SPARK SESSION
 
-    val spark = TaskInitialization.createLocalSparkSession
+    implicit val spark: SparkSession = TaskInitialization.createLocalSparkSession
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF(spark)
-    val productsDF = TaskData.createSampleProductsDF(spark)
-    val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
+    val usersDF = TaskData.createSampleUsersDF
+    val productsDF = TaskData.createSampleProductsDF
+    val categoriesDF = TaskData.createSampleCategoriesDF
+    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
 
     // RUN
 

--- a/src/test/scala/Task2SimpleApproachTest.scala
+++ b/src/test/scala/Task2SimpleApproachTest.scala
@@ -21,11 +21,8 @@ class Task2SimpleApproachTest extends AnyFlatSpec {
     // RUN
 
     val transformationTask2WithSimpleApproachDF = transformationTask2WithSimpleApproach(
-      spark,
       notCompletedOrdersDF,
       completedOrdersDF,
-      notCompletedPaymentsDF,
-      completedPaymentsDF,
       usersDF,
       productsDF,
       categoriesDF
@@ -67,6 +64,6 @@ class Task2SimpleApproachTest extends AnyFlatSpec {
 
     // CLEANUP
 
-    // spark.stop()
+    spark.stop()
   }
 }

--- a/src/test/scala/Task2SimpleApproachTest.scala
+++ b/src/test/scala/Task2SimpleApproachTest.scala
@@ -1,5 +1,5 @@
 import example.Task2SimpleApproach.transformationTask2WithSimpleApproach
-import example.{TaskData, TaskInitialization}
+import example.{TaskDatabase, TaskInitialization}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -11,11 +11,11 @@ class Task2SimpleApproachTest extends AnyFlatSpec {
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF
-    val productsDF = TaskData.createSampleProductsDF
-    val categoriesDF = TaskData.createSampleCategoriesDF
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
+    val usersDF = TaskDatabase.loadSampleUsersDF
+    val productsDF = TaskDatabase.loadSampleProductsDF
+    val categoriesDF = TaskDatabase.loadSampleCategoriesDF
+    val completedOrdersDF = TaskDatabase.loadSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskDatabase.loadSampleNotCompletedOrdersDF
 
     // RUN
 

--- a/src/test/scala/Task2SimpleApproachTest.scala
+++ b/src/test/scala/Task2SimpleApproachTest.scala
@@ -13,8 +13,6 @@ class Task2SimpleApproachTest extends AnyFlatSpec {
     val usersDF = TaskData.createSampleUsersDF(spark)
     val productsDF = TaskData.createSampleProductsDF(spark)
     val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedPaymentsDF = TaskData.createSampleCompletedPaymentsDF(spark)
-    val notCompletedPaymentsDF = TaskData.createSampleNotCompletedPaymentsDF(spark)
     val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
     val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
 

--- a/src/test/scala/Task2SimpleApproachWithComplicationsTest.scala
+++ b/src/test/scala/Task2SimpleApproachWithComplicationsTest.scala
@@ -1,20 +1,21 @@
 import example.Task2SimpleApproachWithComplications.transformationTask2WithSimpleApproachWithComplications
 import example.{TaskData, TaskInitialization}
+import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
 class Task2SimpleApproachWithComplicationsTest extends AnyFlatSpec {
   "Task2SimpleApproachWithComplications" should "returns correct DataFrame" in {
     // CREATE SPARK SESSION
 
-    val spark = TaskInitialization.createLocalSparkSession
+    implicit val spark: SparkSession = TaskInitialization.createLocalSparkSession
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF(spark)
-    val productsDF = TaskData.createSampleProductsDF(spark)
-    val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
+    val usersDF = TaskData.createSampleUsersDF
+    val productsDF = TaskData.createSampleProductsDF
+    val categoriesDF = TaskData.createSampleCategoriesDF
+    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
 
     // RUN
 

--- a/src/test/scala/Task2SimpleApproachWithComplicationsTest.scala
+++ b/src/test/scala/Task2SimpleApproachWithComplicationsTest.scala
@@ -38,29 +38,10 @@ class Task2SimpleApproachWithComplicationsTest extends AnyFlatSpec {
     //  |         user-03|              STEPHANE MOREAU|    ultra-laptops-01|   200.0|
     //  +----------------+-----------------------------+--------------------+--------+
 
-    val results = transformationTask2WithSimpleApproachWithComplicationsDF.collectAsList()
+    val obtainedResults = transformationTask2WithSimpleApproachWithComplicationsDF
+    val expectedResults = TestUtils.getComplicatedQueryExpectedResult(spark)
 
-    assert(results.size() == 4)
-
-    assert(results.get(0).getString(0) == "user-01")
-    assert(results.get(1).getString(0) == "user-02")
-    assert(results.get(2).getString(0) == "user-03")
-    assert(results.get(3).getString(0) == "user-03")
-
-    assert(results.get(0).getString(1) == "ANNE ANDERSON")
-    assert(results.get(1).getString(1) == "TOMMY HARADA")
-    assert(results.get(2).getString(1) == "STEPHANE MOREAU")
-    assert(results.get(3).getString(1) == "STEPHANE MOREAU")
-
-    assert(results.get(0).getString(2) == "office-laptops-01")
-    assert(results.get(1).getString(2) == "premium-laptops-01")
-    assert(results.get(2).getString(2) == "super-laptops-01")
-    assert(results.get(3).getString(2) == "ultra-laptops-01")
-
-    assert(results.get(0).getDouble(3) == 500.0)
-    assert(results.get(1).getDouble(3) == 350.0)
-    assert(results.get(2).getDouble(3) == 300.0)
-    assert(results.get(3).getDouble(3) == 200.0)
+    assert(TestUtils.areDataFrameEquals(obtainedResults, expectedResults))
 
     // CLEANUP
 

--- a/src/test/scala/Task2SimpleApproachWithComplicationsTest.scala
+++ b/src/test/scala/Task2SimpleApproachWithComplicationsTest.scala
@@ -1,5 +1,5 @@
 import example.Task2SimpleApproachWithComplications.transformationTask2WithSimpleApproachWithComplications
-import example.{TaskData, TaskInitialization}
+import example.{TaskDatabase, TaskInitialization}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -11,11 +11,11 @@ class Task2SimpleApproachWithComplicationsTest extends AnyFlatSpec {
 
     // CREATE TEST DATAFRAMES
 
-    val usersDF = TaskData.createSampleUsersDF
-    val productsDF = TaskData.createSampleProductsDF
-    val categoriesDF = TaskData.createSampleCategoriesDF
-    val completedOrdersDF = TaskData.createSampleCompletedOrdersDF
-    val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF
+    val usersDF = TaskDatabase.loadSampleUsersDF
+    val productsDF = TaskDatabase.loadSampleProductsDF
+    val categoriesDF = TaskDatabase.loadSampleCategoriesDF
+    val completedOrdersDF = TaskDatabase.loadSampleCompletedOrdersDF
+    val notCompletedOrdersDF = TaskDatabase.loadSampleNotCompletedOrdersDF
 
     // RUN
 

--- a/src/test/scala/Task2SimpleApproachWithComplicationsTest.scala
+++ b/src/test/scala/Task2SimpleApproachWithComplicationsTest.scala
@@ -13,8 +13,6 @@ class Task2SimpleApproachWithComplicationsTest extends AnyFlatSpec {
     val usersDF = TaskData.createSampleUsersDF(spark)
     val productsDF = TaskData.createSampleProductsDF(spark)
     val categoriesDF = TaskData.createSampleCategoriesDF(spark)
-    val completedPaymentsDF = TaskData.createSampleCompletedPaymentsDF(spark)
-    val notCompletedPaymentsDF = TaskData.createSampleNotCompletedPaymentsDF(spark)
     val completedOrdersDF = TaskData.createSampleCompletedOrdersDF(spark)
     val notCompletedOrdersDF = TaskData.createSampleNotCompletedOrdersDF(spark)
 

--- a/src/test/scala/Task2SimpleApproachWithComplicationsTest.scala
+++ b/src/test/scala/Task2SimpleApproachWithComplicationsTest.scala
@@ -1,4 +1,3 @@
-import example.Task2SimpleApproach.transformationTask2WithSimpleApproach
 import example.Task2SimpleApproachWithComplications.transformationTask2WithSimpleApproachWithComplications
 import example.{TaskData, TaskInitialization}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -22,11 +21,8 @@ class Task2SimpleApproachWithComplicationsTest extends AnyFlatSpec {
     // RUN
 
     val transformationTask2WithSimpleApproachWithComplicationsDF = transformationTask2WithSimpleApproachWithComplications(
-      spark,
       notCompletedOrdersDF,
       completedOrdersDF,
-      notCompletedPaymentsDF,
-      completedPaymentsDF,
       usersDF,
       productsDF,
       categoriesDF,
@@ -70,6 +66,6 @@ class Task2SimpleApproachWithComplicationsTest extends AnyFlatSpec {
 
     // CLEANUP
 
-    // spark.stop()
+    spark.stop()
   }
 }

--- a/src/test/scala/TestUtils.scala
+++ b/src/test/scala/TestUtils.scala
@@ -1,0 +1,63 @@
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+object TestUtils {
+  def areDataFrameEquals(df1: DataFrame, df2: DataFrame): Boolean = {
+    areDataFrameEqualsRegardingSchema(df1, df2) && areDataFrameEqualsRegardingData(df1, df2)
+  }
+  def areDataFrameEqualsRegardingSchema(df1: DataFrame, df2: DataFrame): Boolean = {
+    val sch1 = df1.schema.fields.map(f => (f.name, f.dataType))
+    val sch2 = df2.schema.fields.map(f => (f.name, f.dataType))
+    sch1.diff(sch2).isEmpty && sch2.diff(sch1).isEmpty
+  }
+  def areDataFrameEqualsRegardingData(df1: DataFrame, df2: DataFrame): Boolean = {
+    // Due to converting DFs to Arrays it will work only for small data sets and unit tests.
+    val data1 = df1.collect()
+    val data2 = df2.collect()
+    data1.diff(data2).isEmpty && data2.diff(data1).isEmpty
+  }
+
+  def getBasicQueryExpectedResult(spark: SparkSession): DataFrame = {
+    //  +----------------+--------------------+--------+
+    //  |ConsideredUserId|ConsideredCategoryId|TotalSum|
+    //  +----------------+--------------------+--------+
+    //  |         user-01|   office-laptops-01|   600.0|
+    //  |         user-02|  regular-laptops-01|   400.0|
+    //  |         user-02|  premium-laptops-01|   350.0|
+    //  |         user-03|    super-laptops-01|   300.0|
+    //  |         user-03|    ultra-laptops-01|   200.0|
+    //  +----------------+--------------------+--------+
+
+    spark.createDataFrame(List(
+        ("user-01", "office-laptops-01", 600.0),
+        ("user-02", "regular-laptops-01", 400.0),
+        ("user-02", "premium-laptops-01", 350.0),
+        ("user-03", "super-laptops-01", 300.0),
+        ("user-03", "ultra-laptops-01", 200.0)
+      ))
+      .withColumnRenamed("_1", "ConsideredUserId")
+      .withColumnRenamed("_2", "ConsideredCategoryId")
+      .withColumnRenamed("_3", "TotalSum")
+  }
+
+  def getComplicatedQueryExpectedResult(spark: SparkSession): DataFrame = {
+    //  +----------------+-----------------------------+--------------------+--------+
+    //  |ConsideredUserId|ConsideredFullNameInUpperCase|ConsideredCategoryId|TotalSum|
+    //  +----------------+-----------------------------+--------------------+--------+
+    //  |         user-01|                ANNE ANDERSON|   office-laptops-01|   500.0|
+    //  |         user-02|                 TOMMY HARADA|  premium-laptops-01|   350.0|
+    //  |         user-03|              STEPHANE MOREAU|    super-laptops-01|   300.0|
+    //  |         user-03|              STEPHANE MOREAU|    ultra-laptops-01|   200.0|
+    //  +----------------+-----------------------------+--------------------+--------+
+
+    spark.createDataFrame(List(
+        ("user-01", "ANNE ANDERSON", "office-laptops-01", 500.0),
+        ("user-02", "TOMMY HARADA", "premium-laptops-01", 350.0),
+        ("user-03", "STEPHANE MOREAU", "super-laptops-01", 300.0),
+        ("user-03", "STEPHANE MOREAU", "ultra-laptops-01", 200.0)
+      ))
+      .withColumnRenamed("_1", "ConsideredUserId")
+      .withColumnRenamed("_2", "ConsideredFullNameInUpperCase")
+      .withColumnRenamed("_3", "ConsideredCategoryId")
+      .withColumnRenamed("_4", "TotalSum")
+  }
+}


### PR DESCRIPTION
1. I've commented the code in Scaladoc.
2. I've removed all unnecessary and commented code.
3. I've changed the way I compare DFs in tests.
4. Spark Session is now always passed as implicit parameter.
5. SQL query strings are reformatted.
6. I've done some further refactoring and cleanup. 
7. Regarding loading test data as tables in unit tests.... Here I have a little problem... First, I am not able to overwrite any table that is once saved in the local data warehouse created by Spark. It says that there are already files in the location where I want to write some new data. Second, once I save the data (for the first time) and stop the spark session (end of unit tests or main function), I cannot load the data back when the spark session is initiated once again (next run of main or unit tests). It looks like the communication between the spark session and the local data warehouse is stateful and the state is cleaned once the session is stopped. And once it is run once again the connection with the local data warehouse cannot be reestablished probably. Files are seen, but they are not seen as tables. At least for me it works like this. I've gone through many posts and tutorials and I cannot see why it does not work for me as it should. Maybe I miss some configuration. The closest that I was able to do was to read the data from Parquet files composing the local data warehouse directly - and this is how I have it implemented right now. 
